### PR TITLE
Improve error handling

### DIFF
--- a/src/main/java/io/burt/athena/AthenaStatement.java
+++ b/src/main/java/io/burt/athena/AthenaStatement.java
@@ -82,7 +82,9 @@ public class AthenaStatement implements Statement {
         } catch (TimeoutException ie) {
             throw new SQLTimeoutException(ie);
         } catch (ExecutionException ee) {
-            throw new SQLException(ee);
+            SQLException eee = new SQLException(ee.getCause());
+            eee.addSuppressed(ee);
+            throw eee;
         }
     }
 

--- a/src/main/java/io/burt/athena/result/S3Result.java
+++ b/src/main/java/io/burt/athena/result/S3Result.java
@@ -85,14 +85,20 @@ public class S3Result implements Result {
                 Thread.currentThread().interrupt();
                 return null;
             } catch (ExecutionException e) {
-                throw new SQLException(e.getCause());
+                SQLException ee = new SQLException(e.getCause());
+                ee.addSuppressed(e);
+                throw ee;
             } catch (TimeoutException e) {
                 throw new SQLTimeoutException(e);
             } catch (NoSuchKeyException e) {
                 throw new SQLException(e);
             } catch (RuntimeException e) {
                 if (!(e.getCause() instanceof RuntimeException)) {
-                    throw new SQLException(e.getCause());
+                    SQLException ee = new SQLException(e.getCause());
+                    ee.addSuppressed(e);
+                    throw ee;
+                } else {
+                    throw e;
                 }
             }
         }
@@ -113,14 +119,18 @@ public class S3Result implements Result {
                 Thread.currentThread().interrupt();
                 return false;
             } catch (ExecutionException e) {
-                throw new SQLException(e.getCause());
+                SQLException ee = new SQLException(e.getCause());
+                ee.addSuppressed(e);
+                throw ee;
             } catch (TimeoutException e) {
                 throw new SQLTimeoutException(e);
             } catch (NoSuchKeyException e) {
                 throw new SQLException(e);
             } catch (RuntimeException e) {
                 if (!(e.getCause() instanceof RuntimeException)) {
-                    throw new SQLException(e.getCause());
+                    SQLException ee = new SQLException(e.getCause());
+                    ee.addSuppressed(e);
+                    throw ee;
                 } else {
                     throw e;
                 }

--- a/src/main/java/io/burt/athena/result/StandardResult.java
+++ b/src/main/java/io/burt/athena/result/StandardResult.java
@@ -56,7 +56,9 @@ public class StandardResult implements Result {
             } catch (TimeoutException ie) {
                 throw new SQLTimeoutException(ie);
             } catch (ExecutionException ee) {
-                throw new SQLException(ee.getCause());
+                SQLException eee = new SQLException(ee.getCause());
+                eee.addSuppressed(ee);
+                throw eee;
             }
         }
     }

--- a/src/test/java/io/burt/athena/AthenaStatementTest.java
+++ b/src/test/java/io/burt/athena/AthenaStatementTest.java
@@ -148,14 +148,14 @@ class AthenaStatementTest {
         void throwsWhenStartQueryExecutionThrows() {
             queryExecutionHelper.queueStartQueryExecutionException(InternalServerException.builder().message("b0rk").build());
             Exception e = assertThrows(SQLException.class, this::execute);
-            assertTrue(e.getCause().getCause() instanceof InternalServerException);
+            assertTrue(e.getCause() instanceof InternalServerException);
         }
 
         @Test
         void throwsWhenGetQueryExecutionThrows() {
             queryExecutionHelper.queueStartQueryExecutionException(TooManyRequestsException.builder().message("b0rk").build());
             Exception e = assertThrows(SQLException.class, this::execute);
-            assertTrue(e.getCause().getCause() instanceof TooManyRequestsException);
+            assertTrue(e.getCause() instanceof TooManyRequestsException);
         }
 
         @Test


### PR DESCRIPTION
This makes error handling consistent between the large try blocks in the result classes and the AthenaStatement class by making sure we unwrap ExecutionException in all instances, and that we throw something for all instances of RuntimeError.

In addition, this changes the logic so that we add the outer exception as a suppressed exception in the event that we unwrap an exception to find a cause. From an interface perspective, these wrappers should be internal concepts, but for purposes of debugging, keeping any additional context available in them might be helpful.