### PR TITLE
Implement support for query timeouts

### DIFF
--- a/src/main/java/io/burt/athena/AthenaConnection.java
+++ b/src/main/java/io/burt/athena/AthenaConnection.java
@@ -305,13 +305,13 @@ public class AthenaConnection implements Connection {
     @Override
     public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
         checkClosed();
-        configuration = configuration.withTimeout(Duration.ofMillis(milliseconds));
+        configuration = configuration.withNetworkTimeout(Duration.ofMillis(milliseconds));
     }
 
     @Override
     public int getNetworkTimeout() throws SQLException {
         checkClosed();
-        return (int) configuration.apiCallTimeout().toMillis();
+        return (int) configuration.networkTimeout().toMillis();
     }
 
     @Override

--- a/src/main/java/io/burt/athena/AthenaConnection.java
+++ b/src/main/java/io/burt/athena/AthenaConnection.java
@@ -19,6 +19,7 @@ import java.sql.SQLXML;
 import java.sql.Savepoint;
 import java.sql.Statement;
 import java.sql.Struct;
+import java.time.Clock;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
@@ -45,7 +46,7 @@ public class AthenaConnection implements Connection {
     @Override
     public Statement createStatement() throws SQLException {
         checkClosed();
-        return new AthenaStatement(configuration);
+        return new AthenaStatement(configuration, Clock.systemDefaultZone());
     }
 
     @Override

--- a/src/main/java/io/burt/athena/AthenaDriver.java
+++ b/src/main/java/io/burt/athena/AthenaDriver.java
@@ -133,6 +133,7 @@ public class AthenaDriver implements Driver {
                     workGroup,
                     outputLocation,
                     Duration.ofMinutes(1),
+                    Duration.ofMinutes(30),
                     ResultLoadingStrategy.S3
             );
             return new AthenaConnection(configuration);

--- a/src/main/java/io/burt/athena/AthenaStatement.java
+++ b/src/main/java/io/burt/athena/AthenaStatement.java
@@ -85,8 +85,18 @@ public class AthenaStatement implements Statement {
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             return false;
-        } catch (TimeoutException ie) {
-            throw new SQLTimeoutException(ie);
+        } catch (TimeoutException te) {
+            SQLTimeoutException ste = new SQLTimeoutException(te);
+            if (queryExecutionId != null) {
+                try {
+                    athenaClient.stopQueryExecution(b -> {
+                        b.queryExecutionId(queryExecutionId);
+                    });
+                } catch (Exception e) {
+                    ste.addSuppressed(e);
+                }
+            }
+            throw ste;
         } catch (ExecutionException ee) {
             SQLException eee = new SQLException(ee.getCause());
             eee.addSuppressed(ee);

--- a/src/main/java/io/burt/athena/AthenaStatement.java
+++ b/src/main/java/io/burt/athena/AthenaStatement.java
@@ -11,7 +11,9 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLTimeoutException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
+import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -20,6 +22,7 @@ import java.util.function.Function;
 
 public class AthenaStatement implements Statement {
     private final AthenaAsyncClient athenaClient;
+    private Clock clock;
 
     private ConnectionConfiguration configuration;
     private String queryExecutionId;
@@ -27,9 +30,10 @@ public class AthenaStatement implements Statement {
     private Function<String, Optional<String>> clientRequestTokenProvider;
     private boolean open;
 
-    AthenaStatement(ConnectionConfiguration configuration) {
+    AthenaStatement(ConnectionConfiguration configuration, Clock clock) {
         this.configuration = configuration;
         this.athenaClient = configuration.athenaClient();
+        this.clock = clock;
         this.queryExecutionId = null;
         this.currentResultSet = null;
         this.clientRequestTokenProvider = sql -> Optional.empty();
@@ -74,8 +78,9 @@ public class AthenaStatement implements Statement {
             currentResultSet = null;
         }
         try {
-            queryExecutionId = startQueryExecution(sql);
-            currentResultSet = configuration.pollingStrategy().pollUntilCompleted(this::poll);
+            Instant deadline = clock.instant().plus(configuration.queryTimeout());
+            queryExecutionId = startQueryExecution(sql, deadline);
+            currentResultSet = configuration.pollingStrategy().pollUntilCompleted(() -> poll(deadline));
             return currentResultSet != null;
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
@@ -89,7 +94,7 @@ public class AthenaStatement implements Statement {
         }
     }
 
-    private String startQueryExecution(String sql) throws InterruptedException, ExecutionException, TimeoutException {
+    private String startQueryExecution(String sql, Instant deadline) throws InterruptedException, ExecutionException, TimeoutException {
         return athenaClient
                 .startQueryExecution(b -> {
                     b.queryString(sql);
@@ -98,14 +103,14 @@ public class AthenaStatement implements Statement {
                     b.resultConfiguration(bb -> bb.outputLocation(configuration.outputLocation()));
                     clientRequestTokenProvider.apply(sql).ifPresent(b::clientRequestToken);
                 })
-                .get(networkTimeoutMillis(), TimeUnit.MILLISECONDS)
+                .get(networkTimeoutMillis(deadline), TimeUnit.MILLISECONDS)
                 .queryExecutionId();
     }
 
-    private Optional<ResultSet> poll() throws SQLException, InterruptedException, ExecutionException, TimeoutException {
+    private Optional<ResultSet> poll(Instant deadline) throws SQLException, InterruptedException, ExecutionException, TimeoutException {
         QueryExecution queryExecution = athenaClient
                 .getQueryExecution(b -> b.queryExecutionId(queryExecutionId))
-                .get(networkTimeoutMillis(), TimeUnit.MILLISECONDS)
+                .get(networkTimeoutMillis(deadline), TimeUnit.MILLISECONDS)
                 .queryExecution();
         switch (queryExecution.status().state()) {
             case SUCCEEDED:
@@ -118,8 +123,8 @@ public class AthenaStatement implements Statement {
         }
     }
 
-    private long networkTimeoutMillis() {
-        return Math.min(configuration.networkTimeout().toMillis(), configuration.queryTimeout().toMillis());
+    private long networkTimeoutMillis(Instant deadline) {
+        return Math.max(0, Math.min(configuration.networkTimeout().toMillis(), Duration.between(clock.instant(), deadline).toMillis()));
     }
 
     private ResultSet createResultSet(QueryExecution queryExecution) {

--- a/src/main/java/io/burt/athena/AthenaStatement.java
+++ b/src/main/java/io/burt/athena/AthenaStatement.java
@@ -80,7 +80,7 @@ public class AthenaStatement implements Statement {
         try {
             Instant deadline = clock.instant().plus(configuration.queryTimeout());
             queryExecutionId = startQueryExecution(sql, deadline);
-            currentResultSet = configuration.pollingStrategy().pollUntilCompleted(() -> poll(deadline));
+            currentResultSet = configuration.pollingStrategy().pollUntilCompleted(this::poll, deadline);
             return currentResultSet != null;
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();

--- a/src/main/java/io/burt/athena/AthenaStatement.java
+++ b/src/main/java/io/burt/athena/AthenaStatement.java
@@ -278,6 +278,10 @@ public class AthenaStatement implements Statement {
         throw new UnsupportedOperationException("Not implemented");
     }
 
+    public void setQueryTimeout(Duration timeout) {
+        configuration = configuration.withQueryTimeout(timeout);
+    }
+
     @Override
     public int getQueryTimeout() {
         return (int) configuration.queryTimeout().toMillis() / 1000;
@@ -285,7 +289,7 @@ public class AthenaStatement implements Statement {
 
     @Override
     public void setQueryTimeout(int seconds) {
-        configuration = configuration.withQueryTimeout(Duration.ofSeconds(seconds));
+        setQueryTimeout(Duration.ofSeconds(seconds));
     }
 
     @Override

--- a/src/main/java/io/burt/athena/configuration/ConcreteConnectionConfiguration.java
+++ b/src/main/java/io/burt/athena/configuration/ConcreteConnectionConfiguration.java
@@ -18,24 +18,26 @@ class ConcreteConnectionConfiguration implements ConnectionConfiguration {
     private final String databaseName;
     private final String workGroupName;
     private final String outputLocation;
-    private final Duration timeout;
+    private final Duration networkTimeout;
+    private final Duration queryTimeout;
     private final ResultLoadingStrategy resultLoadingStrategy;
 
     private AthenaAsyncClient athenaClient;
     private S3AsyncClient s3Client;
     private PollingStrategy pollingStrategy;
 
-    ConcreteConnectionConfiguration(Region awsRegion, String databaseName, String workGroupName, String outputLocation, Duration timeout, ResultLoadingStrategy resultLoadingStrategy) {
+    ConcreteConnectionConfiguration(Region awsRegion, String databaseName, String workGroupName, String outputLocation, Duration networkTimeout, Duration queryTimeout, ResultLoadingStrategy resultLoadingStrategy) {
         this.awsRegion = awsRegion;
         this.databaseName = databaseName;
         this.workGroupName = workGroupName;
         this.outputLocation = outputLocation;
-        this.timeout = timeout;
+        this.networkTimeout = networkTimeout;
+        this.queryTimeout = queryTimeout;
         this.resultLoadingStrategy = resultLoadingStrategy;
     }
 
-    private ConcreteConnectionConfiguration(Region awsRegion, String databaseName, String workGroupName, String outputLocation, Duration timeout, ResultLoadingStrategy resultLoadingStrategy, AthenaAsyncClient athenaClient, S3AsyncClient s3Client, PollingStrategy pollingStrategy) {
-        this(awsRegion, databaseName, workGroupName, outputLocation, timeout, resultLoadingStrategy);
+    private ConcreteConnectionConfiguration(Region awsRegion, String databaseName, String workGroupName, String outputLocation, Duration networkTimeout, Duration queryTimeout, ResultLoadingStrategy resultLoadingStrategy, AthenaAsyncClient athenaClient, S3AsyncClient s3Client, PollingStrategy pollingStrategy) {
+        this(awsRegion, databaseName, workGroupName, outputLocation, networkTimeout, queryTimeout, resultLoadingStrategy);
         this.athenaClient = athenaClient;
         this.s3Client = s3Client;
         this.pollingStrategy = pollingStrategy;
@@ -57,9 +59,12 @@ class ConcreteConnectionConfiguration implements ConnectionConfiguration {
     }
 
     @Override
-    public Duration apiCallTimeout() {
-        return timeout;
+    public Duration networkTimeout() {
+        return networkTimeout;
     }
+
+    @Override
+    public Duration queryTimeout() { return queryTimeout; }
 
     @Override
     public AthenaAsyncClient athenaClient() {
@@ -87,12 +92,17 @@ class ConcreteConnectionConfiguration implements ConnectionConfiguration {
 
     @Override
     public ConnectionConfiguration withDatabaseName(String databaseName) {
-        return new ConcreteConnectionConfiguration(awsRegion, databaseName, workGroupName, outputLocation, timeout, resultLoadingStrategy, athenaClient, s3Client, pollingStrategy);
+        return new ConcreteConnectionConfiguration(awsRegion, databaseName, workGroupName, outputLocation, networkTimeout, queryTimeout, resultLoadingStrategy, athenaClient, s3Client, pollingStrategy);
     }
 
     @Override
-    public ConnectionConfiguration withTimeout(Duration timeout) {
-        return new ConcreteConnectionConfiguration(awsRegion, databaseName, workGroupName, outputLocation, timeout, resultLoadingStrategy, athenaClient, s3Client, pollingStrategy);
+    public ConnectionConfiguration withNetworkTimeout(Duration networkTimeout) {
+        return new ConcreteConnectionConfiguration(awsRegion, databaseName, workGroupName, outputLocation, networkTimeout, queryTimeout, resultLoadingStrategy, athenaClient, s3Client, pollingStrategy);
+    }
+
+    @Override
+    public ConnectionConfiguration withQueryTimeout(Duration queryTimeout) {
+        return new ConcreteConnectionConfiguration(awsRegion, databaseName, workGroupName, outputLocation, networkTimeout, queryTimeout, resultLoadingStrategy, athenaClient, s3Client, pollingStrategy);
     }
 
     @Override

--- a/src/main/java/io/burt/athena/configuration/ConnectionConfiguration.java
+++ b/src/main/java/io/burt/athena/configuration/ConnectionConfiguration.java
@@ -15,7 +15,9 @@ public interface ConnectionConfiguration extends AutoCloseable {
 
     String outputLocation();
 
-    Duration apiCallTimeout();
+    Duration networkTimeout();
+
+    Duration queryTimeout();
 
     AthenaAsyncClient athenaClient();
 
@@ -25,7 +27,9 @@ public interface ConnectionConfiguration extends AutoCloseable {
 
     ConnectionConfiguration withDatabaseName(String databaseName);
 
-    ConnectionConfiguration withTimeout(Duration timeout);
+    ConnectionConfiguration withNetworkTimeout(Duration timeout);
+
+    ConnectionConfiguration withQueryTimeout(Duration timeout);
 
     Result createResult(QueryExecution queryExecution);
 }

--- a/src/main/java/io/burt/athena/configuration/ConnectionConfigurationFactory.java
+++ b/src/main/java/io/burt/athena/configuration/ConnectionConfigurationFactory.java
@@ -5,8 +5,8 @@ import software.amazon.awssdk.regions.Region;
 import java.time.Duration;
 
 public class ConnectionConfigurationFactory {
-    public ConnectionConfiguration createConnectionConfiguration(Region awsRegion, String databaseName, String workGroupName, String outputLocation, Duration timeout, ResultLoadingStrategy resultLoadingStrategy) {
-        return new ConcreteConnectionConfiguration(awsRegion, databaseName, workGroupName, outputLocation, timeout, resultLoadingStrategy);
+    public ConnectionConfiguration createConnectionConfiguration(Region awsRegion, String databaseName, String workGroupName, String outputLocation, Duration networkTimeout, Duration queryTimeout, ResultLoadingStrategy resultLoadingStrategy) {
+        return new ConcreteConnectionConfiguration(awsRegion, databaseName, workGroupName, outputLocation, networkTimeout, queryTimeout, resultLoadingStrategy);
     }
 }
 

--- a/src/main/java/io/burt/athena/polling/BackoffPollingStrategy.java
+++ b/src/main/java/io/burt/athena/polling/BackoffPollingStrategy.java
@@ -49,15 +49,7 @@ class BackoffPollingStrategy implements PollingStrategy {
             if (resultSet.isPresent()) {
                 return resultSet.get();
             } else {
-                Duration beforeDeadline = Duration.between(clock.instant(), deadline);
-                if (beforeDeadline.compareTo(nextDelay) < 0) {
-                    if (beforeDeadline.isNegative()) {
-                        throw new TimeoutException();
-                    }
-                    sleeper.sleep(beforeDeadline);
-                } else {
-                    sleeper.sleep(nextDelay);
-                }
+                sleeper.sleep(sleepDuration(nextDelay, clock.instant(), deadline));
                 nextDelay = nextDelay.multipliedBy(factor);
                 if (nextDelay.compareTo(maxDelay) > 0) {
                     nextDelay = maxDelay;

--- a/src/main/java/io/burt/athena/polling/BackoffPollingStrategy.java
+++ b/src/main/java/io/burt/athena/polling/BackoffPollingStrategy.java
@@ -2,7 +2,9 @@ package io.burt.athena.polling;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -13,35 +15,49 @@ class BackoffPollingStrategy implements PollingStrategy {
     private final Duration maxDelay;
     private final long factor;
     private final Sleeper sleeper;
+    private final Clock clock;
 
     BackoffPollingStrategy(Duration firstDelay, Duration maxDelay) {
-        this(firstDelay, maxDelay, 2L, duration -> TimeUnit.MILLISECONDS.sleep(duration.toMillis()));
+        this(firstDelay, maxDelay, 2L, duration -> TimeUnit.MILLISECONDS.sleep(duration.toMillis()), Clock.systemDefaultZone());
     }
 
     BackoffPollingStrategy(Duration firstDelay, Duration maxDelay, long factor) {
-        this(firstDelay, maxDelay, factor, duration -> TimeUnit.MILLISECONDS.sleep(duration.toMillis()));
+        this(firstDelay, maxDelay, factor, duration -> TimeUnit.MILLISECONDS.sleep(duration.toMillis()), Clock.systemDefaultZone());
     }
 
     BackoffPollingStrategy(Duration firstDelay, Duration maxDelay, Sleeper sleeper) {
-        this(firstDelay, maxDelay, 2L, sleeper);
+        this(firstDelay, maxDelay, 2L, sleeper, Clock.systemDefaultZone());
     }
 
-    BackoffPollingStrategy(Duration firstDelay, Duration maxDelay, long factor, Sleeper sleeper) {
+    BackoffPollingStrategy(Duration firstDelay, Duration maxDelay, Sleeper sleeper, Clock clock) {
+        this(firstDelay, maxDelay, 2L, sleeper, clock);
+    }
+
+    BackoffPollingStrategy(Duration firstDelay, Duration maxDelay, long factor, Sleeper sleeper, Clock clock) {
         this.firstDelay = firstDelay;
         this.maxDelay = maxDelay;
         this.factor = factor;
         this.sleeper = sleeper;
+        this.clock = clock;
     }
 
     @Override
-    public ResultSet pollUntilCompleted(PollingCallback callback) throws SQLException, TimeoutException, ExecutionException, InterruptedException {
+    public ResultSet pollUntilCompleted(PollingCallback callback, Instant deadline) throws SQLException, TimeoutException, ExecutionException, InterruptedException {
         Duration nextDelay = firstDelay;
         while (true) {
-            Optional<ResultSet> resultSet = callback.poll();
+            Optional<ResultSet> resultSet = callback.poll(deadline);
             if (resultSet.isPresent()) {
                 return resultSet.get();
             } else {
-                sleeper.sleep(nextDelay);
+                Duration beforeDeadline = Duration.between(clock.instant(), deadline);
+                if (beforeDeadline.compareTo(nextDelay) < 0) {
+                    if (beforeDeadline.isNegative()) {
+                        throw new TimeoutException();
+                    }
+                    sleeper.sleep(beforeDeadline);
+                } else {
+                    sleeper.sleep(nextDelay);
+                }
                 nextDelay = nextDelay.multipliedBy(factor);
                 if (nextDelay.compareTo(maxDelay) > 0) {
                     nextDelay = maxDelay;

--- a/src/main/java/io/burt/athena/polling/FixedDelayPollingStrategy.java
+++ b/src/main/java/io/burt/athena/polling/FixedDelayPollingStrategy.java
@@ -32,15 +32,7 @@ public class FixedDelayPollingStrategy implements PollingStrategy {
             if (resultSet.isPresent()) {
                 return resultSet.get();
             } else {
-                Duration beforeDeadline = Duration.between(clock.instant(), deadline);
-                if (beforeDeadline.compareTo(delay) < 0) {
-                    if (beforeDeadline.isNegative()) {
-                        throw new TimeoutException();
-                    }
-                    sleeper.sleep(beforeDeadline);
-                } else {
-                    sleeper.sleep(delay);
-                }
+                sleeper.sleep(sleepDuration(delay, clock.instant(), deadline));
             }
         }
     }

--- a/src/main/java/io/burt/athena/polling/PollingCallback.java
+++ b/src/main/java/io/burt/athena/polling/PollingCallback.java
@@ -2,11 +2,12 @@ package io.burt.athena.polling;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 @FunctionalInterface
 public interface PollingCallback {
-    Optional<ResultSet> poll() throws SQLException, TimeoutException, ExecutionException, InterruptedException;
+    Optional<ResultSet> poll(Instant deadline) throws SQLException, TimeoutException, ExecutionException, InterruptedException;
 }

--- a/src/main/java/io/burt/athena/polling/PollingStrategy.java
+++ b/src/main/java/io/burt/athena/polling/PollingStrategy.java
@@ -2,9 +2,10 @@ package io.burt.athena.polling;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 public interface PollingStrategy {
-    ResultSet pollUntilCompleted(PollingCallback callback) throws SQLException, TimeoutException, ExecutionException, InterruptedException;
+    ResultSet pollUntilCompleted(PollingCallback callback, Instant deadline) throws SQLException, TimeoutException, ExecutionException, InterruptedException;
 }

--- a/src/main/java/io/burt/athena/polling/PollingStrategy.java
+++ b/src/main/java/io/burt/athena/polling/PollingStrategy.java
@@ -2,10 +2,23 @@ package io.burt.athena.polling;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 public interface PollingStrategy {
     ResultSet pollUntilCompleted(PollingCallback callback, Instant deadline) throws SQLException, TimeoutException, ExecutionException, InterruptedException;
+
+    default Duration sleepDuration(Duration desired, Instant now, Instant deadline) throws TimeoutException {
+        Duration beforeDeadline = Duration.between(now, deadline);
+        if (beforeDeadline.compareTo(desired) < 0) {
+            if (beforeDeadline.isNegative()) {
+                throw new TimeoutException("polling reached deadline");
+            }
+            return beforeDeadline;
+        } else {
+            return desired;
+        }
+    }
 }

--- a/src/test/java/io/burt/athena/AthenaConnectionTest.java
+++ b/src/test/java/io/burt/athena/AthenaConnectionTest.java
@@ -74,6 +74,7 @@ class AthenaConnectionTest {
                 "test_wg",
                 "s3://test/location",
                 Duration.ofSeconds(1),
+                Duration.ofSeconds(1),
                 () -> queryExecutionHelper,
                 () -> null,
                 () -> pollingStrategy,

--- a/src/test/java/io/burt/athena/AthenaConnectionTest.java
+++ b/src/test/java/io/burt/athena/AthenaConnectionTest.java
@@ -58,9 +58,9 @@ class AthenaConnectionTest {
     }
 
     PollingStrategy createPollingStrategy() {
-        return callback -> {
+        return (callback, deadline) -> {
             while (true) {
-                Optional<ResultSet> rs = callback.poll();
+                Optional<ResultSet> rs = callback.poll(deadline);
                 if (rs.isPresent()) {
                     return rs.get();
                 }

--- a/src/test/java/io/burt/athena/AthenaDataSourceTest.java
+++ b/src/test/java/io/burt/athena/AthenaDataSourceTest.java
@@ -43,7 +43,7 @@ class AthenaDataSourceTest {
     @BeforeEach
     void setUp() {
         connectionConfigurationFactory = spy(new ConnectionConfigurationFactory());
-        lenient().when(connectionConfigurationFactory.createConnectionConfiguration(any(), any(), any(), any(), any(), any())).then(invocation -> {
+        lenient().when(connectionConfigurationFactory.createConnectionConfiguration(any(), any(), any(), any(), any(), any(), any())).then(invocation -> {
             ConnectionConfiguration cc = (ConnectionConfiguration) invocation.callRealMethod();
             cc = spy(cc);
             lenient().when(cc.athenaClient()).thenReturn(queryExecutionHelper);
@@ -72,7 +72,7 @@ class AthenaDataSourceTest {
         void createsAnAthenaClientForTheConfiguredRegion() throws Exception {
             dataSource.setRegion("sa-east-1");
             dataSource.getConnection();
-            verify(connectionConfigurationFactory).createConnectionConfiguration(eq(Region.SA_EAST_1), any(), any(), any(), any(), any());
+            verify(connectionConfigurationFactory).createConnectionConfiguration(eq(Region.SA_EAST_1), any(), any(), any(), any(), any(), any());
         }
 
         @Test
@@ -105,7 +105,7 @@ class AthenaDataSourceTest {
             void setsTheRegionOfTheAthenaClient() throws Exception {
                 dataSource.setRegion("ca-central-1");
                 dataSource.getConnection();
-                verify(connectionConfigurationFactory).createConnectionConfiguration(eq(Region.CA_CENTRAL_1), any(), any(), any(), any(), any());
+                verify(connectionConfigurationFactory).createConnectionConfiguration(eq(Region.CA_CENTRAL_1), any(), any(), any(), any(), any(), any());
             }
         }
     }

--- a/src/test/java/io/burt/athena/AthenaDriverTest.java
+++ b/src/test/java/io/burt/athena/AthenaDriverTest.java
@@ -47,7 +47,7 @@ class AthenaDriverTest implements PomVersionLoader {
     @BeforeEach
     void setUpDriver() {
         connectionConfigurationFactory = spy(new ConnectionConfigurationFactory());
-        lenient().when(connectionConfigurationFactory.createConnectionConfiguration(any(), any(), any(), any(), any(), any())).then(invocation -> {
+        lenient().when(connectionConfigurationFactory.createConnectionConfiguration(any(), any(), any(), any(), any(), any(), any())).then(invocation -> {
             ConnectionConfiguration cc = (ConnectionConfiguration) invocation.callRealMethod();
             cc = spy(cc);
             lenient().when(cc.athenaClient()).thenReturn(queryExecutionHelper);
@@ -95,7 +95,7 @@ class AthenaDriverTest implements PomVersionLoader {
         @Test
         void usesTheAwsRegionFromTheProperties() {
             driver.connect("jdbc:athena", defaultProperties);
-            verify(connectionConfigurationFactory).createConnectionConfiguration(eq(Region.AP_SOUTHEAST_1), any(), any(), any(), any(), any());
+            verify(connectionConfigurationFactory).createConnectionConfiguration(eq(Region.AP_SOUTHEAST_1), any(), any(), any(), any(), any(), any());
         }
 
         @Test

--- a/src/test/java/io/burt/athena/AthenaResultSetTest.java
+++ b/src/test/java/io/burt/athena/AthenaResultSetTest.java
@@ -74,7 +74,7 @@ class AthenaResultSetTest {
     @BeforeEach
     void setUpResultSet() {
         parentStatement = mock(AthenaStatement.class);
-        connectionConfiguration = new ConfigurableConnectionConfiguration("test_db", "test_wg", "s3://test/location", Duration.ofMillis(10), () -> null, () -> null, () -> null, (q) -> null);
+        connectionConfiguration = new ConfigurableConnectionConfiguration("test_db", "test_wg", "s3://test/location", Duration.ofMillis(10), Duration.ofMillis(10), () -> null, () -> null, () -> null, (q) -> null);
         QueryExecution queryExecution = QueryExecution.builder().queryExecutionId("Q1234").build();
         queryResultsHelper = new GetQueryResultsHelper();
         Result result = new PreloadingStandardResult(queryResultsHelper, queryExecution, StandardResult.MAX_FETCH_SIZE, Duration.ofSeconds(1));

--- a/src/test/java/io/burt/athena/AthenaStatementTest.java
+++ b/src/test/java/io/burt/athena/AthenaStatementTest.java
@@ -61,9 +61,9 @@ class AthenaStatementTest {
     }
 
     PollingStrategy createPollingStrategy() {
-        return callback -> {
+        return (callback, deadline) -> {
             while (true) {
-                Optional<ResultSet> rs = callback.poll();
+                Optional<ResultSet> rs = callback.poll(deadline);
                 if (rs.isPresent()) {
                     return rs.get();
                 }
@@ -238,7 +238,7 @@ class AthenaStatementTest {
 
             @BeforeEach
             void setUp() {
-                pollingStrategy = callback -> {
+                pollingStrategy = (callback, deadline) -> {
                     throw new InterruptedException();
                 };
                 executeResult = new AtomicReference<>(null);

--- a/src/test/java/io/burt/athena/AthenaStatementTest.java
+++ b/src/test/java/io/burt/athena/AthenaStatementTest.java
@@ -517,9 +517,9 @@ class AthenaStatementTest {
 
         @Test
         void setsTheTimeoutUsedForQuerySpanningMultipleOperations() {
-            queryExecutionHelper.delayStartQueryExecutionResponses(Duration.ofMillis(400));
-            queryExecutionHelper.delayGetQueryExecutionResponses(Duration.ofMillis(400));
-            statement.setQueryTimeout(1);
+            queryExecutionHelper.delayStartQueryExecutionResponses(Duration.ofMillis(40));
+            queryExecutionHelper.delayGetQueryExecutionResponses(Duration.ofMillis(40));
+            statement.setQueryTimeout(Duration.ofMillis(100));
             assertThrows(SQLTimeoutException.class, () -> statement.executeQuery("SELECT 1"));
         }
     }

--- a/src/test/java/io/burt/athena/polling/FixedDelayPollingStrategyTest.java
+++ b/src/test/java/io/burt/athena/polling/FixedDelayPollingStrategyTest.java
@@ -1,5 +1,6 @@
 package io.burt.athena.polling;
 
+import io.burt.athena.support.TestClock;
 import io.burt.athena.support.TestNameGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -11,6 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -27,12 +29,14 @@ import static org.mockito.internal.verification.VerificationModeFactory.times;
 @DisplayNameGeneration(TestNameGenerator.class)
 class FixedDelayPollingStrategyTest {
     private Sleeper sleeper;
+    private TestClock clock;
     private PollingStrategy pollingStrategy;
 
     @BeforeEach
     void setUp() {
         sleeper = mock(Sleeper.class);
-        pollingStrategy = new FixedDelayPollingStrategy(Duration.ofSeconds(3), sleeper);
+        clock = new TestClock();
+        pollingStrategy = new FixedDelayPollingStrategy(Duration.ofSeconds(3), sleeper, clock);
     }
 
     @Nested
@@ -40,35 +44,58 @@ class FixedDelayPollingStrategyTest {
         @Test
         void pollsUntilTheCallbackReturnsAResultSet() throws Exception {
             AtomicInteger counter = new AtomicInteger(0);
-            pollingStrategy.pollUntilCompleted(() -> {
+            pollingStrategy.pollUntilCompleted((Instant deadline) -> {
                 if (counter.get() == 3) {
                     return Optional.of(mock(ResultSet.class));
                 } else {
                     counter.incrementAndGet();
                     return Optional.empty();
                 }
-            });
+            }, clock.instant().plus(Duration.ofSeconds(30)));
             assertEquals(3, counter.get());
         }
 
         @Test
         void returnsTheResultSet() throws Exception {
             ResultSet rs1 = mock(ResultSet.class);
-            ResultSet rs2 = pollingStrategy.pollUntilCompleted(() -> Optional.of(rs1));
+            ResultSet rs2 = pollingStrategy.pollUntilCompleted((Instant deadline) -> Optional.of(rs1), clock.instant().plus(Duration.ofSeconds(30)));
             assertSame(rs1, rs2);
         }
 
         @Test
         void delaysTheConfiguredDurationBetweenPolls() throws Exception {
             AtomicInteger counter = new AtomicInteger(0);
-            pollingStrategy.pollUntilCompleted(() -> {
+            pollingStrategy.pollUntilCompleted((Instant deadline) -> {
                 if (counter.getAndIncrement() == 3) {
                     return Optional.of(mock(ResultSet.class));
                 } else {
                     return Optional.empty();
                 }
-            });
+            }, clock.instant().plus(Duration.ofSeconds(30)));
             verify(sleeper, times(3)).sleep(Duration.ofSeconds(3));
+        }
+
+        @Test
+        void reducesFinalDelayToMatchDeadline() throws Exception {
+            AtomicInteger counter = new AtomicInteger(0);
+            pollingStrategy.pollUntilCompleted((Instant deadline) -> {
+                if (counter.getAndIncrement() >= 1) {
+                    return Optional.of(mock(ResultSet.class));
+                } else {
+                    return Optional.empty();
+                }
+            }, clock.instant().plus(Duration.ofMillis(100)));
+            verify(sleeper, times(1)).sleep(Duration.ofMillis(100));
+        }
+
+        @Test
+        void throwsTimeoutExceptionIfNotCompletedWithinDeadline() throws Exception {
+            assertThrows(TimeoutException.class, () -> {
+               pollingStrategy.pollUntilCompleted((Instant deadline) -> {
+                   clock.tick(Duration.ofSeconds(10));
+                   return Optional.empty();
+               }, clock.instant());
+            });
         }
 
         @Nested
@@ -76,24 +103,24 @@ class FixedDelayPollingStrategyTest {
             @Test
             void passesTheExceptionAlong() {
                 assertThrows(InterruptedException.class, () -> {
-                    pollingStrategy.pollUntilCompleted(() -> {
+                    pollingStrategy.pollUntilCompleted((Instant deadline) -> {
                         throw new InterruptedException();
-                    });
+                    }, clock.instant().plus(Duration.ofSeconds(30)));
                 });
                 assertThrows(SQLException.class, () -> {
-                    pollingStrategy.pollUntilCompleted(() -> {
+                    pollingStrategy.pollUntilCompleted((Instant deadline) -> {
                         throw new SQLException();
-                    });
+                    }, clock.instant().plus(Duration.ofSeconds(30)));
                 });
                 assertThrows(ExecutionException.class, () -> {
-                    pollingStrategy.pollUntilCompleted(() -> {
+                    pollingStrategy.pollUntilCompleted((Instant deadline) -> {
                         throw new ExecutionException(new ArithmeticException());
-                    });
+                    }, clock.instant().plus(Duration.ofSeconds(30)));
                 });
                 assertThrows(TimeoutException.class, () -> {
-                    pollingStrategy.pollUntilCompleted(() -> {
+                    pollingStrategy.pollUntilCompleted((Instant deadline) -> {
                         throw new TimeoutException();
-                    });
+                    }, clock.instant().plus(Duration.ofSeconds(30)));
                 });
             }
         }

--- a/src/test/java/io/burt/athena/support/ConfigurableConnectionConfiguration.java
+++ b/src/test/java/io/burt/athena/support/ConfigurableConnectionConfiguration.java
@@ -15,17 +15,19 @@ public class ConfigurableConnectionConfiguration implements ConnectionConfigurat
     private final String databaseName;
     private final String workGroupName;
     private final String outputLocation;
-    private final Duration timeout;
+    private final Duration networkTimeout;
+    private final Duration queryTimeout;
     private final Supplier<AthenaAsyncClient> athenaClientFactory;
     private final Supplier<S3AsyncClient> s3ClientFactory;
     private final Supplier<PollingStrategy> pollingStrategyFactory;
     private final Function<QueryExecution, Result> resultFactory;
 
-    public ConfigurableConnectionConfiguration(String databaseName, String workGroupName, String outputLocation, Duration timeout, Supplier<AthenaAsyncClient> athenaClientFactory, Supplier<S3AsyncClient> s3ClientFactory, Supplier<PollingStrategy> pollingStrategyFactory, Function<QueryExecution, Result> resultFactory) {
+    public ConfigurableConnectionConfiguration(String databaseName, String workGroupName, String outputLocation, Duration networkTimeout, Duration queryTimeout, Supplier<AthenaAsyncClient> athenaClientFactory, Supplier<S3AsyncClient> s3ClientFactory, Supplier<PollingStrategy> pollingStrategyFactory, Function<QueryExecution, Result> resultFactory) {
         this.databaseName = databaseName;
         this.workGroupName = workGroupName;
         this.outputLocation = outputLocation;
-        this.timeout = timeout;
+        this.networkTimeout = networkTimeout;
+        this.queryTimeout = queryTimeout;
         this.athenaClientFactory = athenaClientFactory;
         this.s3ClientFactory = s3ClientFactory;
         this.pollingStrategyFactory = pollingStrategyFactory;
@@ -48,9 +50,12 @@ public class ConfigurableConnectionConfiguration implements ConnectionConfigurat
     }
 
     @Override
-    public Duration apiCallTimeout() {
-        return timeout;
+    public Duration networkTimeout() {
+        return networkTimeout;
     }
+
+    @Override
+    public Duration queryTimeout() { return queryTimeout; }
 
     @Override
     public AthenaAsyncClient athenaClient() {
@@ -69,12 +74,17 @@ public class ConfigurableConnectionConfiguration implements ConnectionConfigurat
 
     @Override
     public ConnectionConfiguration withDatabaseName(String newDatabaseName) {
-        return new ConfigurableConnectionConfiguration(newDatabaseName, workGroupName, outputLocation, timeout, athenaClientFactory, s3ClientFactory, pollingStrategyFactory, resultFactory);
+        return new ConfigurableConnectionConfiguration(newDatabaseName, workGroupName, outputLocation, networkTimeout, queryTimeout, athenaClientFactory, s3ClientFactory, pollingStrategyFactory, resultFactory);
     }
 
     @Override
-    public ConnectionConfiguration withTimeout(Duration newTimeout) {
-        return new ConfigurableConnectionConfiguration(databaseName, workGroupName, outputLocation, newTimeout, athenaClientFactory, s3ClientFactory, pollingStrategyFactory, resultFactory);
+    public ConnectionConfiguration withNetworkTimeout(Duration newNetworkTimeout) {
+        return new ConfigurableConnectionConfiguration(databaseName, workGroupName, outputLocation, newNetworkTimeout, queryTimeout, athenaClientFactory, s3ClientFactory, pollingStrategyFactory, resultFactory);
+    }
+
+    @Override
+    public ConnectionConfiguration withQueryTimeout(Duration newQueryTimeout) {
+        return new ConfigurableConnectionConfiguration(databaseName, workGroupName, outputLocation, networkTimeout, newQueryTimeout, athenaClientFactory, s3ClientFactory, pollingStrategyFactory, resultFactory);
     }
 
     @Override

--- a/src/test/java/io/burt/athena/support/QueryExecutionHelper.java
+++ b/src/test/java/io/burt/athena/support/QueryExecutionHelper.java
@@ -40,8 +40,14 @@ public class QueryExecutionHelper implements AthenaAsyncClient {
     private Duration getQueryResultsDelay;
     private Lock getQueryExecutionBlocker;
     private boolean open;
+    private TestClock clock;
 
     public QueryExecutionHelper() {
+        this(new TestClock());
+    }
+
+    public QueryExecutionHelper(TestClock clock) {
+        this.clock = clock;
         this.startQueryRequests = new LinkedList<>();
         this.getQueryExecutionRequests = new LinkedList<>();
         this.getQueryResultsRequests = new LinkedList<>();
@@ -147,6 +153,8 @@ public class QueryExecutionHelper implements AthenaAsyncClient {
                             newFuture.completeExceptionally(e.getCause());
                         } catch (Exception e) {
                             newFuture.completeExceptionally(e);
+                        } finally {
+                            clock.tick(delay);
                         }
                     },
                     delay.toMillis(),

--- a/src/test/java/io/burt/athena/support/TestClock.java
+++ b/src/test/java/io/burt/athena/support/TestClock.java
@@ -1,0 +1,34 @@
+package io.burt.athena.support;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+
+public class TestClock extends Clock {
+  private long millis;
+
+  @Override
+  public ZoneId getZone() {
+    return ZoneId.of("UTC");
+  }
+
+  @Override
+  public Clock withZone(ZoneId zone) {
+    return null;
+  }
+
+  @Override
+  public Instant instant() {
+    return Instant.ofEpochMilli(millis());
+  }
+
+  @Override
+  public long millis() {
+    return this.millis;
+  }
+
+  public void tick(Duration duration) {
+    this.millis += duration.toMillis();
+  }
+}


### PR DESCRIPTION
The configuration used to only have an API timeout, and if my reading of the JDBC documentation is correct, this would correspond the specified network timeout for JDBC, although for proper handling it should probably also go into the HTTP client inside the AWS SDK in order to ensure we close sockets promptly and not leave operations running.

As far as I understand, the query timeout should instead apply to the full query operation, and not the individual network requests. This implements query timeouts by computing a deadline at the beginning of a query operation, and then limiting any wait to not go (much) beyond that.

In order to free up Athena resources when a query times out, this make an attempt to cancel the query (if StartQueryExecution has returned). This doesn't actually wait for the cancellation to go through, and any failure reported in cancellation will just be ignored. Given that we have already used up all the time the user said we had, it seems unreasonable to wait for the cancellation to finish, but unfortunately there isn't a good way to report a failure to do so in that case.

Consult the individual commit messages for additional details.