### PR TITLE
Specify trusty dist for Oracle Java builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: java
-jdk:
-  - oraclejdk8
-  - oraclejdk9
-  - openjdk8
+matrix:
+  include:
+    - jdk: oraclejdk8
+      dist: trusty
+    - jdk: oraclejdk9
+      dist: trusty
+    - jdk: openjdk8
 script: mvn test -Djunit.jupiter.execution.parallel.enabled=false


### PR DESCRIPTION
As the default dist doesn't seem to have Oracle Java builds anymore

I suppose another option would be to remove the Oracle Java builds.