### PR TITLE
Throw exceptions when interrupted

### DIFF
--- a/src/main/java/io/burt/athena/AthenaStatement.java
+++ b/src/main/java/io/burt/athena/AthenaStatement.java
@@ -84,7 +84,7 @@ public class AthenaStatement implements Statement {
             return currentResultSet != null;
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
-            return false;
+            throw new SQLException(ie);
         } catch (TimeoutException te) {
             SQLTimeoutException ste = new SQLTimeoutException(te);
             if (queryExecutionId != null) {

--- a/src/main/java/io/burt/athena/result/S3Result.java
+++ b/src/main/java/io/burt/athena/result/S3Result.java
@@ -92,7 +92,7 @@ public class S3Result implements Result {
                 start();
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                return null;
+                throw new SQLException(e);
             }
         }
         return responseParser.getMetaData();
@@ -110,7 +110,7 @@ public class S3Result implements Result {
                 start();
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                return false;
+                throw new SQLException(e);
             }
         }
         currentRow = responseParser.next();

--- a/src/main/java/io/burt/athena/result/StandardResult.java
+++ b/src/main/java/io/burt/athena/result/StandardResult.java
@@ -104,7 +104,7 @@ public class StandardResult implements Result {
                 ensureResults();
             } catch (InterruptedException ie) {
                 Thread.currentThread().interrupt();
-                return null;
+                throw new SQLException(ie);
             }
         }
         return resultSetMetaData;
@@ -128,7 +128,7 @@ public class StandardResult implements Result {
             return currentRow != null;
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
-            return false;
+            throw new SQLException(ie);
         }
     }
 

--- a/src/main/java/io/burt/athena/result/s3/InputStreamResponseTransformer.java
+++ b/src/main/java/io/burt/athena/result/s3/InputStreamResponseTransformer.java
@@ -124,7 +124,7 @@ public class InputStreamResponseTransformer extends InputStream implements Async
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                return false;
+                throw new IOException(e);
             }
         }
         return true;


### PR DESCRIPTION
In the presence of an InterruptedException, you should either re-raise it or set the interrupted flag. In our case, we can't really re-raise the exception as is, as it is a checked exception and the throws clauses are constrained by interfaces.

The previous implementation returned something simple, but that result is typically meant to signify something else. For example, returning -1 from a InputStream.read operation signals that we successfully reached end-of-file, whereas an InterruptedException typically means we were aborted before then, and signaling end-of-file would typically result in a parse failure that effectively discards the original exception and reason for failure.

Thus, this instead changes the behavior to wrap the InterruptedException in another Exception with the required signature matching the interface throws clause. In a caller where you once again control the return signature, you might want to check the interrupted flag and throw a new InterruptedException.