### PR TITLE
Allow S3Result to be closed after failed open

### DIFF
--- a/src/main/java/io/burt/athena/result/S3Result.java
+++ b/src/main/java/io/burt/athena/result/S3Result.java
@@ -145,7 +145,9 @@ public class S3Result implements Result {
     @Override
     public void close() throws SQLException {
         try {
-            responseParser.close();
+            if (responseParser != null) {
+                responseParser.close();
+            }
         } catch (IOException e) {
             throw new SQLException(e);
         }

--- a/src/test/java/io/burt/athena/result/S3ResultTest.java
+++ b/src/test/java/io/burt/athena/result/S3ResultTest.java
@@ -462,5 +462,12 @@ class S3ResultTest {
                 assertTrue(publisher.subscription.cancelled);
             }
         }
+
+        @Test
+        void canBeCalledAfterAFailedOpen() throws Exception {
+            getObjectHelper.removeObject("some-bucket", "the/prefix/Q1234.csv");
+            try { result.next(); } catch(SQLException e) { /* expected */ }
+            result.close();
+        }
     }
 }


### PR DESCRIPTION
This will also allow the result to be closed when no method was actively called, but that seems ok.