### PR TITLE
Add support for longer binary protobuf fields

### DIFF
--- a/src/main/java/io/burt/athena/result/protobuf/VeryBasicProtobufParser.java
+++ b/src/main/java/io/burt/athena/result/protobuf/VeryBasicProtobufParser.java
@@ -42,7 +42,7 @@ public class VeryBasicProtobufParser {
     }
 
     private byte[] readLengthDelimited(ByteBuffer buffer) {
-        int size = Byte.toUnsignedInt(buffer.get());
+        int size = Math.toIntExact(readVarint(buffer));
         byte[] contents = new byte[size];
         buffer.get(contents);
         return contents;

--- a/src/test/java/io/burt/athena/result/protobuf/VeryBasicProtobufParserTest.java
+++ b/src/test/java/io/burt/athena/result/protobuf/VeryBasicProtobufParserTest.java
@@ -89,5 +89,21 @@ class VeryBasicProtobufParserTest {
                 assertEquals(0, ((IntegerField) innerFields.get(7)).getValue());
             }
         }
+
+        @Nested
+        class WithMultiByteBinaryFieldLengths {
+            @Test
+            void returnsLongBinaryFields() throws Exception {
+                byte[] contents = new byte[514];
+                contents[0] = 2;
+                contents[1] = (byte)(0xff);
+                contents[2] = (byte)(0x03);
+                contents[0xff+2] = 2;
+                contents[0xff+3] = (byte)(0x1ff-0xff-1);
+                List<Field> fields = parser.parse(contents);
+                assertEquals(1, fields.size());
+                assertEquals(0x1ff, ((BinaryField)fields.get(0)).getContents().length);
+            }
+        }
     }
 }


### PR DESCRIPTION
The length is encoded with a varint, but the code was only reading the first byte, which typically works well, but in the event that the name of a column (and type) is long, the buffer length value is over 127, and requires more than one byte of storage. In this case, the previous parsing would continue to parse the the middle of the binary field as another protobuf field, which typically resulted in a either a buffer-underflow exception or an unsupported field type exception.