### PR TITLE
Decode S3 result using UTF-8

### DIFF
--- a/src/main/java/io/burt/athena/result/S3Result.java
+++ b/src/main/java/io/burt/athena/result/S3Result.java
@@ -12,6 +12,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.sql.SQLTimeoutException;
 import java.time.Duration;
@@ -158,7 +159,7 @@ public class S3Result implements Result {
         private final AthenaResultSetMetaData metaData;
 
         ResponseParser(InputStream responseStream, AthenaResultSetMetaData metaData) {
-            super(new BufferedReader(new InputStreamReader(responseStream)), metaData.getColumnCount());
+            super(new BufferedReader(new InputStreamReader(responseStream, StandardCharsets.UTF_8)), metaData.getColumnCount());
             this.responseStream = responseStream;
             this.metaData = metaData;
         }

--- a/src/test/java/io/burt/athena/result/S3ResultTest.java
+++ b/src/test/java/io/burt/athena/result/S3ResultTest.java
@@ -42,9 +42,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class S3ResultTest {
     private GetObjectHelper getObjectHelper;
     private S3Result result;
+    private String previousFileEncoding;
 
     @BeforeEach
     void setUp() {
+        previousFileEncoding = System.getProperty("file.encoding");
+        System.setProperty("file.encoding", "ascii");
         QueryExecution queryExecution = QueryExecution
                 .builder()
                 .queryExecutionId("Q1234")
@@ -57,6 +60,7 @@ class S3ResultTest {
     @AfterEach
     void tearDown() {
         getObjectHelper.close();
+        System.setProperty("file.encoding", previousFileEncoding);
     }
 
     private ByteBuffer createMetadata(List<ColumnInfo> columns) {
@@ -102,7 +106,7 @@ class S3ResultTest {
         contents.append("\"col1\",\"col2\"\n");
         contents.append("\"row1\",\"1\"\n");
         contents.append("\"row2\",\"2\"\n");
-        contents.append("\"row3\",\"3\"\n");
+        contents.append("\"row\u2603\",\"3\"\n");
         getObjectHelper.setObject("some-bucket", "the/prefix/Q1234.csv", contents.toString().getBytes(StandardCharsets.UTF_8));
 
     }
@@ -275,7 +279,7 @@ class S3ResultTest {
             assertEquals("row2", result.getString(1));
             assertEquals("2", result.getString(2));
             result.next();
-            assertEquals("row3", result.getString(1));
+            assertEquals("row\u2603", result.getString(1));
             assertEquals("3", result.getString(2));
         }
 


### PR DESCRIPTION
Today S3 result is decoded with Java's default encoding which depends on the environment. We should always decode it using UTF-8.

We have previously used this driver in an application ("Analytics") get results with UTF-8 characters correctly. We recently switched another application ("Hamster") to this driver and it works fine locally, but in production all non-ASCII characters are replaced with "�". The reason seems to be that these applications are deployed differently, and the locale for the second application is not UTF-8, so the default encoding in Java is "wrong".

A workaround is to run Java with `-Dfile.encoding=UTF-8`, but it would be better if the driver was not dependent on the environment.