### PR TITLE
Build fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,12 @@
   </distributionManagement>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
           <pushChanges>false</pushChanges>
           <tagNameFormat>athena-jdbc-@{project.version}</tagNameFormat>
           <useReleaseProfile>false</useReleaseProfile>
-          <releaseProfiles>release</releaseProfiles>
+          <releaseProfiles>athena-jdbc-release</releaseProfiles>
           <goals>deploy</goals>
         </configuration>
       </plugin>
@@ -170,7 +170,7 @@
 
   <profiles>
     <profile>
-      <id>release</id>
+      <id>athena-jdbc-release</id>
       <build>
         <plugins>
           <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -153,9 +153,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.1.1</version>
-        <configuration>
-          <additionalOptions>-html5</additionalOptions>
-        </configuration>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -202,6 +199,24 @@
             </executions>
           </plugin>
         </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>javadoc-html5</id>
+      <activation>
+        <jdk>[1.9,)</jdk>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <configuration>
+                <additionalOptions>-html5</additionalOptions>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
       </build>
     </profile>
   </profiles>

--- a/src/main/java/io/burt/athena/AthenaDatabaseMetaData.java
+++ b/src/main/java/io/burt/athena/AthenaDatabaseMetaData.java
@@ -39,17 +39,17 @@ class AthenaDatabaseMetaData implements DatabaseMetaData {
 
     @Override
     public String getDriverVersion() {
-        return "0.2.0";
+        return AthenaDriverInfo.getDriverVersion();
     }
 
     @Override
     public int getDriverMajorVersion() {
-        return 0;
+        return AthenaDriverInfo.getDriverMajorVersion();
     }
 
     @Override
     public int getDriverMinorVersion() {
-        return 2;
+        return AthenaDriverInfo.getDriverMinorVersion();
     }
 
     @Override

--- a/src/main/java/io/burt/athena/AthenaDriver.java
+++ b/src/main/java/io/burt/athena/AthenaDriver.java
@@ -158,12 +158,12 @@ public class AthenaDriver implements Driver {
 
     @Override
     public int getMajorVersion() {
-        return 0;
+        return AthenaDriverInfo.getDriverMajorVersion();
     }
 
     @Override
     public int getMinorVersion() {
-        return 2;
+        return AthenaDriverInfo.getDriverMinorVersion();
     }
 
     @Override

--- a/src/main/java/io/burt/athena/AthenaDriverInfo.java
+++ b/src/main/java/io/burt/athena/AthenaDriverInfo.java
@@ -1,0 +1,42 @@
+package io.burt.athena;
+
+import java.io.IOException;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class AthenaDriverInfo {
+    private static final String driverVersion;
+    private static final int driverMajorVersion;
+    private static final int driverMinorVersion;
+
+    static {
+        final Properties properties = new Properties();
+        try {
+            properties.load(AthenaDatabaseMetaData.class.getClassLoader().getResourceAsStream("project.properties"));
+        } catch (IOException e) {
+            throw new RuntimeException("Could not load driver version: " + e.getMessage(), e);
+        }
+        driverVersion = properties.getProperty("project.version");
+        final Pattern versionComponentsPattern = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)(?:-\\w+)?");
+        final Matcher matcher = versionComponentsPattern.matcher(driverVersion);
+        if (matcher.matches()) {
+            driverMajorVersion = Integer.parseInt(matcher.group(1));
+            driverMinorVersion = Integer.parseInt(matcher.group(2));
+        } else {
+            throw new RuntimeException("Could not parse driver version: " + driverVersion);
+        }
+    }
+
+    static String getDriverVersion() {
+        return driverVersion;
+    }
+
+    static int getDriverMajorVersion() {
+        return driverMajorVersion;
+    }
+
+    static int getDriverMinorVersion() {
+        return driverMinorVersion;
+    }
+}

--- a/src/main/resources/project.properties
+++ b/src/main/resources/project.properties
@@ -1,0 +1,1 @@
+project.version=${project.version}


### PR DESCRIPTION
This fixes a number of issues with the build system. I actually implemented these back in February, but didn't get around to creating a PR until now.

Automatically set driver version from artifact version
---
The version of the driver was hard coded in `AthenaDatabaseMetaData` which causes the tests to fail when bumping the version during the release process. To fix this we create a properties file, and tell Maven to write the project version to this file. Then we load and parse the version number from this properties file.

I have tried various other solutions that involve replacing the version in the code directly, but none of them works when running the unit tests.

Rename release profile
---
For some reason the "release" profile is always active, which causes it to try to sign the jar file even when doing a simple `mvn install`. Not sure what activates it, but renaming it seems to prevent it from happening.

Only specify HTML5 javadoc in version 1.9 or higher
---
When building the jar in Java 8 it fails because the `-html5` flag is not supported.

~~Move to next snapshot release~~
---
~~This should have been done after the last release.~~ Should not be done as part of this PR.