### PR TITLE
Simplify InputStreamResponseTransformer subscription feedback

### DIFF
--- a/src/main/java/io/burt/athena/result/s3/InputStreamResponseTransformer.java
+++ b/src/main/java/io/burt/athena/result/s3/InputStreamResponseTransformer.java
@@ -82,7 +82,7 @@ public class InputStreamResponseTransformer extends InputStream implements Async
 
     private void maybeRequestMore(int currentSize) {
         if (currentSize < TARGET_BUFFER_SIZE) {
-            subscription.request(10L);
+            subscription.request(1L);
         }
     }
 


### PR DESCRIPTION
The previous approach attempted to throttle the S3 download by measuring the bytes received, since we can only request chunk of unknown sizes from the subscription, rather than a specified number o f bytes. While the previous commit avoided the 10x buffering, the ramp-up in capacity becomes slow, and doing something better would require some additional bookkeeping and guesswork.

Instead of trying to track the number of inflight bytes, this settles for just keeping 30 chunks in flight. When running both locally and in our production environment, the typical chunk size seem to align around 1500 bytes per chunk, which would mean that this effectively aims for a target buffer of about 45k in flight. This is much smaller than the previous 32MB, but given that we want to process a CSV-result line-by-line, it seems like 45k should typically be enough to cover at least a bunch of lines. It is also not clear how the chunk size is derived, and if that will stay consistent, and if it was bumped to 8k instead, the 30 in-flight requests would correspond to about 240k instead.

The first version of this just reduced the fetch size from ten to one, and that ought to workaround the problem, but it's not really clear to me whether the extra logic brings much additional value over the simpler approach.