### PR TITLE
Bump AWS SDK to 2.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
   </developers>
 
   <properties>
-    <aws-sdk.version>2.5.37</aws-sdk.version>
+    <aws-sdk.version>2.13.1</aws-sdk.version>
     <slf4j.version>1.7.26</slf4j.version>
     <junit.version>5.4.2</junit.version>
     <mockito.version>2.27.0</mockito.version>


### PR DESCRIPTION
We got a mail from AWS a while back:

> One or more applications in your AWS account has a dependency on asynchronous features of AWS SDK for Java V2. In versions below 2.10.56 of the AWS SDK for Java V2, the asynchronous clients (e.g. S3AsyncClient, SqsAsyncClient) resolve and cache the IP address of AWS Services once per channel pool, and the resolved IP is then used for all future connections to the host name until the client is closed. As a result, applications that use long-lived asynchronous SDK clients could use stale IP addresses to AWS services that can result in exceptions, and potentially not use the breadth of load balancing that the service provides, causing increased overall latency.
>
> What Do I Need to Do?
> Please upgrade your application dependency to AWS Java V2 SDK [2.10.56](https://mvnrepository.com/artifact/software.amazon.awssdk/netty-nio-client/2.10.56).

This bumps AWS SDK to the latest version which happens to be 2.13.1.