### PR TITLE
Improve InputStreamResponseTransformer subscription feedback 

### DIFF
--- a/src/main/java/io/burt/athena/result/s3/InputStreamResponseTransformer.java
+++ b/src/main/java/io/burt/athena/result/s3/InputStreamResponseTransformer.java
@@ -82,7 +82,7 @@ public class InputStreamResponseTransformer extends InputStream implements Async
 
     private void maybeRequestMore(int currentSize) {
         if (currentSize < TARGET_BUFFER_SIZE) {
-            subscription.request(10L);
+            subscription.request(1L);
         }
     }
 


### PR DESCRIPTION
Sadly, it turns out that the simplifications in #16 didn't really cut it from a performance perspective, so this instead tries to improve upon the existing byte-based buffering.

Ideally, all of this wouldn't be a problem, and the numbers you requested from the aws-sdk would be in bytes rather than chunks, as then you could just increase the number to the buffer size whenever the combined buffer size was below that point.

The main problem in estimating the impact of the additional requests is that we don't know how large the corresponding chunks will be. This uses a simple exponentially-weighted average over chunk sizes received in the past and assumes that the in-flight chunks are equally large. If the chunk sizes stay consistent, or don't change too dramatically in sizes, this should work well.

In the event that the chunk sizes grow significantly we might still overshoot by a lot, so as an additional precaution we don't allow having more than 1000 chunks of unknown sizes in flight. If the chunk sizes changes rapidly and grow beyond 32k we could still be in trouble, but that seems very unlikely to happen, and we have to make some assumptions or else we can't request any data at all using the requests abstraction.

