### PR TITLE
Make tests timing independent

### DIFF
--- a/src/test/java/io/burt/athena/AthenaStatementTest.java
+++ b/src/test/java/io/burt/athena/AthenaStatementTest.java
@@ -197,14 +197,14 @@ class AthenaStatementTest {
         class WhenInterruptedWhileSleeping {
             @BeforeEach
             void setUp() {
-                statement = new AthenaStatement(createConfiguration().withNetworkTimeout(Duration.ofMillis(10)), clock);
+                statement = new AthenaStatement(createConfiguration().withNetworkTimeout(Duration.ofSeconds(10)), clock);
             }
 
             @Test
             void throwsWhenStartQueryExecutionDurationExceedsNetworkTimeout() {
                 queryExecutionHelper.queueStartQueryResponse("Q1234");
                 queryExecutionHelper.queueGetQueryExecutionResponse(QueryExecutionState.SUCCEEDED);
-                queryExecutionHelper.delayStartQueryExecutionResponses(Duration.ofMillis(100));
+                queryExecutionHelper.delayStartQueryExecutionResponses(Duration.ofSeconds(100));
                 assertThrows(SQLTimeoutException.class, () -> statement.executeQuery("SELECT 1"));
             }
 
@@ -212,7 +212,7 @@ class AthenaStatementTest {
             void throwsWhenGetQueryExecutionDurationExceedsNetworkTimeout() {
                 queryExecutionHelper.queueStartQueryResponse("Q1234");
                 queryExecutionHelper.queueGetQueryExecutionResponse(QueryExecutionState.SUCCEEDED);
-                queryExecutionHelper.delayGetQueryExecutionResponses(Duration.ofMillis(100));
+                queryExecutionHelper.delayGetQueryExecutionResponses(Duration.ofSeconds(100));
                 assertThrows(SQLTimeoutException.class, () -> statement.executeQuery("SELECT 1"));
             }
         }
@@ -507,29 +507,29 @@ class AthenaStatementTest {
 
         @Test
         void setsTheTimeoutUsedForStartQueryExecution() throws SQLException {
-            queryExecutionHelper.delayStartQueryExecutionResponses(Duration.ofMillis(10));
+            queryExecutionHelper.delayStartQueryExecutionResponses(Duration.ofSeconds(10));
             statement.setQueryTimeout(0);
             assertThrows(SQLTimeoutException.class, () -> statement.executeQuery("SELECT 1"));
         }
 
         @Test
         void setsTheTimeoutUsedForGetQueryExecution() throws SQLException {
-            queryExecutionHelper.delayGetQueryExecutionResponses(Duration.ofMillis(10));
+            queryExecutionHelper.delayGetQueryExecutionResponses(Duration.ofSeconds(10));
             statement.setQueryTimeout(0);
             assertThrows(SQLTimeoutException.class, () -> statement.executeQuery("SELECT 1"));
         }
 
         @Test
         void setsTheTimeoutUsedForQuerySpanningMultipleOperations() {
-            queryExecutionHelper.delayStartQueryExecutionResponses(Duration.ofMillis(40));
-            queryExecutionHelper.delayGetQueryExecutionResponses(Duration.ofMillis(40));
-            statement.setQueryTimeout(Duration.ofMillis(100));
+            queryExecutionHelper.delayStartQueryExecutionResponses(Duration.ofSeconds(40));
+            queryExecutionHelper.delayGetQueryExecutionResponses(Duration.ofSeconds(40));
+            statement.setQueryTimeout(Duration.ofSeconds(100));
             assertThrows(SQLTimeoutException.class, () -> statement.executeQuery("SELECT 1"));
         }
 
         @Test
         void cancelsQueryAfterTimeout() throws Exception {
-            queryExecutionHelper.delayGetQueryExecutionResponses(Duration.ofMillis(10));
+            queryExecutionHelper.delayGetQueryExecutionResponses(Duration.ofSeconds(10));
             statement.setQueryTimeout(0);
             try { statement.executeQuery("SELECT 1"); } catch (SQLTimeoutException ste) { /* expected */ }
             StopQueryExecutionRequest request = queryExecutionHelper.stopQueryExecutionRequests().get(0);
@@ -538,7 +538,7 @@ class AthenaStatementTest {
 
         @Test
         void doesNotCancelQueryThatDidNotStart() throws Exception {
-            queryExecutionHelper.delayStartQueryExecutionResponses(Duration.ofMillis(10));
+            queryExecutionHelper.delayStartQueryExecutionResponses(Duration.ofSeconds(10));
             statement.setQueryTimeout(0);
             try { statement.executeQuery("SELECT 1"); } catch (SQLTimeoutException ste) { /* expected */ }
             assertEquals(0, queryExecutionHelper.stopQueryExecutionRequests().size());

--- a/src/test/java/io/burt/athena/result/S3ResultTest.java
+++ b/src/test/java/io/burt/athena/result/S3ResultTest.java
@@ -54,7 +54,7 @@ class S3ResultTest {
                 .resultConfiguration(b -> b.outputLocation("s3://some-bucket/the/prefix/Q1234.csv"))
                 .build();
         getObjectHelper = new GetObjectHelper();
-        result = new S3Result(getObjectHelper, queryExecution, Duration.ofMillis(10));
+        result = new S3Result(getObjectHelper, queryExecution, Duration.ofSeconds(10));
     }
 
     @AfterEach
@@ -122,7 +122,7 @@ class S3ResultTest {
                         .queryExecutionId("Q1234")
                         .resultConfiguration(b -> b.outputLocation("://some-bucket/the/prefix/Q1234.csv"))
                         .build();
-                Exception e = assertThrows(IllegalArgumentException.class, () -> new S3Result(getObjectHelper, queryExecution, Duration.ofMillis(10)));
+                Exception e = assertThrows(IllegalArgumentException.class, () -> new S3Result(getObjectHelper, queryExecution, Duration.ofSeconds(10)));
                 assertTrue(e.getMessage().contains("\"://some-bucket/the/prefix/Q1234.csv\""));
                 assertTrue(e.getMessage().contains("malformed"));
             }
@@ -213,7 +213,7 @@ class S3ResultTest {
         class WhenLoadingTheMetaDataTimesOut {
             @Test
             void throwsSqlTimeoutException() {
-                getObjectHelper.delayObject("some-bucket", "the/prefix/Q1234.csv.metadata", Duration.ofSeconds(1));
+                getObjectHelper.delayObject("some-bucket", "the/prefix/Q1234.csv.metadata", Duration.ofSeconds(60));
                 Exception e = assertThrows(SQLTimeoutException.class, () -> result.getMetaData());
                 assertEquals(TimeoutException.class, e.getCause().getClass());
             }
@@ -320,7 +320,7 @@ class S3ResultTest {
         class WhenLoadingTheResultTimesOut {
             @Test
             void throwsSqlTimeoutException() {
-                getObjectHelper.delayObject("some-bucket", "the/prefix/Q1234.csv", Duration.ofSeconds(1));
+                getObjectHelper.delayObject("some-bucket", "the/prefix/Q1234.csv", Duration.ofSeconds(60));
                 Exception e = assertThrows(SQLTimeoutException.class, () -> result.next());
                 assertEquals(TimeoutException.class, e.getCause().getClass());
             }

--- a/src/test/java/io/burt/athena/result/StandardResultTest.java
+++ b/src/test/java/io/burt/athena/result/StandardResultTest.java
@@ -45,7 +45,7 @@ class StandardResultTest {
 
     protected StandardResult createResult(AthenaAsyncClient athenaClient) {
         QueryExecution queryExecution = QueryExecution.builder().queryExecutionId("Q1234").build();
-        return new StandardResult(queryResultsHelper, queryExecution, 123, Duration.ofMillis(10));
+        return new StandardResult(queryResultsHelper, queryExecution, 123, Duration.ofSeconds(10));
     }
 
     @BeforeEach
@@ -348,7 +348,7 @@ class StandardResultTest {
             @Test
             void throwsSQLTimeoutException() {
                 QueryExecution queryExecution = QueryExecution.builder().queryExecutionId("Q1234").build();
-                queryResultsHelper.delayResponses(Duration.ofMillis(10));
+                queryResultsHelper.delayResponses(Duration.ofSeconds(10));
                 result = new StandardResult(queryResultsHelper, queryExecution, 123, Duration.ZERO);
                 Exception e = assertThrows(Exception.class, () -> result.next());
                 assertEquals(SQLTimeoutException.class, e.getClass());

--- a/src/test/java/io/burt/athena/support/QueryExecutionHelper.java
+++ b/src/test/java/io/burt/athena/support/QueryExecutionHelper.java
@@ -139,7 +139,7 @@ public class QueryExecutionHelper implements AthenaAsyncClient {
         if (delay.isZero()) {
             return future;
         } else {
-            return TestDelayedCompletableFuture.create(future, delay, clock);
+            return TestDelayedCompletableFuture.wrapWithDelay(future, delay, clock);
         }
     }
 

--- a/src/test/java/io/burt/athena/support/QueryExecutionHelper.java
+++ b/src/test/java/io/burt/athena/support/QueryExecutionHelper.java
@@ -1,6 +1,5 @@
 package io.burt.athena.support;
 
-import org.mockito.AdditionalAnswers;
 import software.amazon.awssdk.services.athena.AthenaAsyncClient;
 import software.amazon.awssdk.services.athena.model.ColumnInfo;
 import software.amazon.awssdk.services.athena.model.GetQueryExecutionRequest;
@@ -19,16 +18,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
 
 public class QueryExecutionHelper implements AthenaAsyncClient {
     private final List<StartQueryExecutionRequest> startQueryRequests;
@@ -147,16 +139,7 @@ public class QueryExecutionHelper implements AthenaAsyncClient {
         if (delay.isZero()) {
             return future;
         } else {
-            TestDelayedCompletableFuture<T> testFuture = new TestDelayedCompletableFuture<>(future, delay, clock);
-            @SuppressWarnings("unchecked") CompletableFuture<T> restrictedFuture = mock(CompletableFuture.class, invocation -> {
-                throw new UnsupportedOperationException(invocation.getMethod().toString());
-            });
-            try {
-                doAnswer(AdditionalAnswers.delegatesTo(testFuture)).when(restrictedFuture).get(anyLong(), any());
-            } catch (ExecutionException | InterruptedException | TimeoutException e) {
-                throw new RuntimeException(e);
-            }
-            return restrictedFuture;
+            return TestDelayedCompletableFuture.create(future, delay, clock);
         }
     }
 

--- a/src/test/java/io/burt/athena/support/TestClock.java
+++ b/src/test/java/io/burt/athena/support/TestClock.java
@@ -4,9 +4,10 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class TestClock extends Clock {
-  private long millis;
+  private AtomicLong millis = new AtomicLong();
 
   @Override
   public ZoneId getZone() {
@@ -25,10 +26,10 @@ public class TestClock extends Clock {
 
   @Override
   public long millis() {
-    return this.millis;
+    return this.millis.get();
   }
 
   public void tick(Duration duration) {
-    this.millis += duration.toMillis();
+    this.millis.addAndGet(duration.toMillis());
   }
 }

--- a/src/test/java/io/burt/athena/support/TestDelayedCompletableFuture.java
+++ b/src/test/java/io/burt/athena/support/TestDelayedCompletableFuture.java
@@ -19,6 +19,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
 
 public class TestDelayedCompletableFuture<T> extends CompletableFuture<T> {
     private static final Executor EXECUTOR = Executors.newCachedThreadPool();
@@ -26,12 +27,16 @@ public class TestDelayedCompletableFuture<T> extends CompletableFuture<T> {
     private CompletableFuture<T> wrappedFuture;
     private TestClock clock;
 
-
     public static <T> CompletableFuture<T> wrap(CompletableFuture<T> future, TestClock clock) {
         TestDelayedCompletableFuture<T> testFuture = new TestDelayedCompletableFuture<>(future, clock);
-        @SuppressWarnings("unchecked") TestDelayedCompletableFuture<T> restrictedFuture = mock(TestDelayedCompletableFuture.class, invocation -> {
-            throw new UnsupportedOperationException(invocation.getMethod().toString());
-        });
+        @SuppressWarnings("unchecked") TestDelayedCompletableFuture<T> restrictedFuture = mock(
+            TestDelayedCompletableFuture.class,
+            withSettings()
+              .stubOnly()
+              .defaultAnswer(invocation -> {
+                throw new UnsupportedOperationException(invocation.getMethod().toString());
+            })
+        );
         try {
             Stubber stubber = lenient().doAnswer(AdditionalAnswers.delegatesTo(testFuture));
             stubber.when(restrictedFuture).getWrappedFuture();

--- a/src/test/java/io/burt/athena/support/TestDelayedCompletableFuture.java
+++ b/src/test/java/io/burt/athena/support/TestDelayedCompletableFuture.java
@@ -1,0 +1,32 @@
+package io.burt.athena.support;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class TestDelayedCompletableFuture<T> extends CompletableFuture<T> {
+    public CompletableFuture<T> wrappedFuture;
+    public Instant finishedAt;
+    public TestClock clock;
+
+    public TestDelayedCompletableFuture(CompletableFuture<T> wrappedFuture, Duration delay, TestClock clock) {
+        this.wrappedFuture = wrappedFuture;
+        this.finishedAt = clock.instant().plus(delay);
+        this.clock = clock;
+    }
+
+    @Override
+    public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        Instant deadline = clock.instant().plusMillis(unit.toMillis(timeout));
+        if (deadline.isBefore(finishedAt)) {
+            clock.tick(Duration.ofMillis(deadline.toEpochMilli()));
+            throw new TimeoutException("simulated timeout");
+        } else {
+            clock.tick(Duration.ofMillis(finishedAt.toEpochMilli()));
+            return wrappedFuture.get();
+        }
+    }
+}

--- a/src/test/java/io/burt/athena/support/TestDelayedCompletableFuture.java
+++ b/src/test/java/io/burt/athena/support/TestDelayedCompletableFuture.java
@@ -1,52 +1,103 @@
 package io.burt.athena.support;
 
 import org.mockito.AdditionalAnswers;
+import org.mockito.stubbing.Stubber;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
 public class TestDelayedCompletableFuture<T> extends CompletableFuture<T> {
-    public CompletableFuture<T> wrappedFuture;
-    public Instant finishedAt;
-    public TestClock clock;
+    private static final Executor EXECUTOR = Executors.newCachedThreadPool();
 
-    static <T> CompletableFuture<T> create(CompletableFuture<T> future, Duration delay, TestClock clock) {
-        TestDelayedCompletableFuture<T> testFuture = new TestDelayedCompletableFuture<>(future, delay, clock);
-        @SuppressWarnings("unchecked") CompletableFuture<T> restrictedFuture = mock(CompletableFuture.class, invocation -> {
+    private CompletableFuture<T> wrappedFuture;
+    private TestClock clock;
+
+
+    public static <T> CompletableFuture<T> wrap(CompletableFuture<T> future, TestClock clock) {
+        TestDelayedCompletableFuture<T> testFuture = new TestDelayedCompletableFuture<>(future, clock);
+        @SuppressWarnings("unchecked") TestDelayedCompletableFuture<T> restrictedFuture = mock(TestDelayedCompletableFuture.class, invocation -> {
             throw new UnsupportedOperationException(invocation.getMethod().toString());
         });
         try {
-            doAnswer(AdditionalAnswers.delegatesTo(testFuture)).when(restrictedFuture).get(anyLong(), any());
+            Stubber stubber = lenient().doAnswer(AdditionalAnswers.delegatesTo(testFuture));
+            stubber.when(restrictedFuture).getWrappedFuture();
+            stubber.when(restrictedFuture).get(anyLong(), any());
+            stubber.when(restrictedFuture).thenApply(any());
+            stubber.when(restrictedFuture).thenCombine(any(), any());
+            stubber.when(restrictedFuture).toString();
         } catch (ExecutionException | InterruptedException | TimeoutException e) {
             throw new RuntimeException(e);
         }
         return restrictedFuture;
     }
 
-    private TestDelayedCompletableFuture(CompletableFuture<T> wrappedFuture, Duration delay, TestClock clock) {
+    public static <T> CompletableFuture<T> wrapWithDelay(CompletableFuture<T> future, Duration delay, TestClock clock) {
+        if (delay == null || delay.compareTo(Duration.ZERO) <= 0) {
+            return wrap(future, clock);
+        } else {
+            CompletableFuture<T> newFuture = new CompletableFuture<>();
+            EXECUTOR.execute(() -> {
+                clock.tick(delay);
+                try {
+                    newFuture.complete(future.get());
+                } catch (Exception e) {
+                    newFuture.completeExceptionally(e);
+                }
+            });
+            return wrap(newFuture, clock);
+        }
+    }
+
+    private TestDelayedCompletableFuture(CompletableFuture<T> wrappedFuture, TestClock clock) {
         this.wrappedFuture = wrappedFuture;
-        this.finishedAt = clock.instant().plus(delay);
         this.clock = clock;
+    }
+
+    public CompletableFuture<T> getWrappedFuture() {
+        return wrappedFuture;
+    }
+
+    private <U> CompletableFuture<U> unwrap(CompletionStage<U> stage) {
+        if (stage instanceof TestDelayedCompletableFuture) {
+            return ((TestDelayedCompletableFuture<U>) stage).getWrappedFuture();
+        } else {
+            return stage.toCompletableFuture();
+        }
     }
 
     @Override
     public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-        Instant deadline = clock.instant().plusMillis(unit.toMillis(timeout));
-        if (deadline.isBefore(finishedAt)) {
-            clock.tick(Duration.ofMillis(deadline.toEpochMilli()));
+        Instant deadline = Instant.ofEpochMilli(unit.toMillis(timeout));
+        T result = wrappedFuture.get(timeout, unit);
+        if (deadline.isBefore(clock.instant())) {
             throw new TimeoutException("simulated timeout");
         } else {
-            clock.tick(Duration.ofMillis(finishedAt.toEpochMilli()));
-            return wrappedFuture.get();
+            return result;
         }
+    }
+
+    @Override
+    public <U> CompletableFuture<U> thenApply(Function<? super T, ? extends U> fn) {
+        return new TestDelayedCompletableFuture<>(unwrap(wrappedFuture.thenApply(fn)), clock);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <U, V> CompletableFuture<V> thenCombine(CompletionStage<? extends U> other, BiFunction<? super T, ? super U, ? extends V> fn) {
+        return new TestDelayedCompletableFuture<>(unwrap(wrappedFuture.thenCombine(unwrap(other), fn)), clock);
     }
 }

--- a/src/test/java/io/burt/athena/support/TestDelayedCompletableFuture.java
+++ b/src/test/java/io/burt/athena/support/TestDelayedCompletableFuture.java
@@ -1,5 +1,7 @@
 package io.burt.athena.support;
 
+import org.mockito.AdditionalAnswers;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
@@ -7,12 +9,30 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
 public class TestDelayedCompletableFuture<T> extends CompletableFuture<T> {
     public CompletableFuture<T> wrappedFuture;
     public Instant finishedAt;
     public TestClock clock;
 
-    public TestDelayedCompletableFuture(CompletableFuture<T> wrappedFuture, Duration delay, TestClock clock) {
+    static <T> CompletableFuture<T> create(CompletableFuture<T> future, Duration delay, TestClock clock) {
+        TestDelayedCompletableFuture<T> testFuture = new TestDelayedCompletableFuture<>(future, delay, clock);
+        @SuppressWarnings("unchecked") CompletableFuture<T> restrictedFuture = mock(CompletableFuture.class, invocation -> {
+            throw new UnsupportedOperationException(invocation.getMethod().toString());
+        });
+        try {
+            doAnswer(AdditionalAnswers.delegatesTo(testFuture)).when(restrictedFuture).get(anyLong(), any());
+        } catch (ExecutionException | InterruptedException | TimeoutException e) {
+            throw new RuntimeException(e);
+        }
+        return restrictedFuture;
+    }
+
+    private TestDelayedCompletableFuture(CompletableFuture<T> wrappedFuture, Duration delay, TestClock clock) {
         this.wrappedFuture = wrappedFuture;
         this.finishedAt = clock.instant().plus(delay);
         this.clock = clock;


### PR DESCRIPTION
When working on releasing version 0.3.0, the process was significantly more frustrating because the tests results were very flaky and about every third run failed due to a timing issue.

In order to avoid the timing issues, this replaces the current actual scheduling delays in the racy tests with simulated delays using the test clock added in #4.

In order to simulate this, a subclass for delayed completable futures is introduced, that implements the get method by checking whether the explicit delay specified in the constructor is within the deadline specified by the arguments.

Unfortunately, the completable future interface is absolutely massive, and we don't want to implement every method. Luckily, we are (thus far) only using the get method with an explicit time period, and thus it is enough to implement that.

In order for the tests to not become silently meaningless if we start using additional aspects of the interface, the delayed feature is wrapped using a restrictive mock object that raises an exception when any other method is called.