### PR TITLE
Allow delayed pagination of results streamed from S3

### DIFF
--- a/src/main/java/io/burt/athena/configuration/ConcreteConnectionConfiguration.java
+++ b/src/main/java/io/burt/athena/configuration/ConcreteConnectionConfiguration.java
@@ -110,7 +110,7 @@ class ConcreteConnectionConfiguration implements ConnectionConfiguration {
         if (resultLoadingStrategy == ResultLoadingStrategy.GET_EXECUTION_RESULTS) {
             return new PreloadingStandardResult(athenaClient(), queryExecution, StandardResult.MAX_FETCH_SIZE, Duration.ofSeconds(10));
         } else if (resultLoadingStrategy == ResultLoadingStrategy.S3) {
-            return new S3Result(s3Client(), queryExecution, Duration.ofSeconds(10));
+            return new S3Result(s3Client(), 10, queryExecution, Duration.ofSeconds(10));
         } else {
             throw new IllegalStateException(String.format("No such result loading strategy: %s", queryExecution));
         }

--- a/src/main/java/io/burt/athena/result/S3Result.java
+++ b/src/main/java/io/burt/athena/result/S3Result.java
@@ -114,7 +114,17 @@ public class S3Result implements Result {
                 throw new SQLException(e);
             }
         }
-        currentRow = responseParser.next();
+        try {
+            currentRow = responseParser.next();
+        } catch (RuntimeException e) {
+            if (!(e.getCause() instanceof RuntimeException)) {
+                SQLException ee = new SQLException(e.getCause());
+                ee.addSuppressed(e);
+                throw ee;
+            } else {
+                throw e;
+            }
+        }
         if (currentRow == null) {
             return false;
         } else {

--- a/src/main/java/io/burt/athena/result/s3/AsyncResumableGetObjectOperation.java
+++ b/src/main/java/io/burt/athena/result/s3/AsyncResumableGetObjectOperation.java
@@ -1,0 +1,222 @@
+package io.burt.athena.result.s3;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.core.internal.util.NoopSubscription;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Consumer;
+
+
+public class AsyncResumableGetObjectOperation<ReturnT> implements Callable<CompletableFuture<ReturnT>> {
+    private final S3AsyncClient s3AsyncClient;
+    private final GetObjectRequest.Builder requestBuilder;
+    private final AsyncResponseTransformer<GetObjectResponse, ReturnT> targetTransformer;
+    private int retryLimit;
+
+    public AsyncResumableGetObjectOperation(S3AsyncClient s3AsyncClient, Consumer<GetObjectRequest.Builder> request, AsyncResponseTransformer<GetObjectResponse, ReturnT> targetTransformer, int retryLimit) {
+        this(s3AsyncClient, GetObjectRequest.builder().applyMutation(request), targetTransformer, retryLimit);
+    }
+
+    public AsyncResumableGetObjectOperation(S3AsyncClient s3AsyncClient, GetObjectRequest request, AsyncResponseTransformer<GetObjectResponse, ReturnT> targetTransformer, int retryLimit) {
+        this(s3AsyncClient, request.toBuilder(), targetTransformer, retryLimit);
+    }
+
+    public AsyncResumableGetObjectOperation(S3AsyncClient s3AsyncClient, GetObjectRequest.Builder requestBuilder, AsyncResponseTransformer<GetObjectResponse, ReturnT> targetTransformer, int retryLimit) {
+        this.s3AsyncClient = s3AsyncClient;
+        this.requestBuilder = requestBuilder;
+        this.targetTransformer = targetTransformer;
+        this.retryLimit = retryLimit;
+    }
+
+    public CompletableFuture<ReturnT> call() {
+        return s3AsyncClient.getObject(
+            requestBuilder.build(),
+            new WrapperAsyncResponseTransformer()
+        );
+    }
+
+    private class WrapperAsyncResponseTransformer implements AsyncResponseTransformer<GetObjectResponse, ReturnT>, SdkPublisher<ByteBuffer>, Subscription, Subscriber<ByteBuffer> {
+        private final AtomicReference<SdkPublisher<ByteBuffer>> sourcePublisher = new AtomicReference<>();
+        private final AtomicReference<Subscription> sourceSubscription = new AtomicReference<>();
+        private final AtomicBoolean isBeforeFirstBody = new AtomicBoolean(true);
+        private final AtomicBoolean isCancelled = new AtomicBoolean();
+        private final AtomicReference<Subscriber<? super ByteBuffer>> targetSubscriber = new AtomicReference<>();
+        private final Set<Throwable> delayedExceptions = new CopyOnWriteArraySet<>();
+        private final AtomicBoolean hasSubscribed = new AtomicBoolean();
+        private final AtomicBoolean hasOnSubscribedTarget = new AtomicBoolean();
+        private final LongAdder bytesReceived = new LongAdder();
+        private long messagesRequested = 0L;
+
+        @Override
+        public CompletableFuture<ReturnT> prepare() {
+            if (isBeforeFirstBody.get()) {
+                return targetTransformer.prepare();
+            } else {
+                return new CompletableFuture<>();
+            }
+        }
+
+        @Override
+        public void onResponse(GetObjectResponse response) {
+            if (isBeforeFirstBody.get()) {
+                requestBuilder.ifMatch(response.eTag());
+                targetTransformer.onResponse(response);
+            }
+        }
+
+        @Override
+        public void onStream(SdkPublisher<ByteBuffer> sdkPublisher) {
+            sourcePublisher.set(sdkPublisher);
+            if (isBeforeFirstBody.getAndSet(false)) {
+                targetTransformer.onStream(this);
+            } else {
+                sdkPublisher.subscribe(this);
+            }
+        }
+
+        @Override
+        public void exceptionOccurred(Throwable throwable) {
+            delayedExceptions.add(throwable);
+            if (sourcePublisher.get() == null) {
+                failTarget();
+            }
+        }
+
+        private void failTarget() {
+            Throwable resolved = resolveDelayedException();
+            targetTransformer.exceptionOccurred(resolved);
+            Subscriber<? super ByteBuffer> subscriber = targetSubscriber.getAndSet(null);
+            if (subscriber != null) {
+                subscriber.onError(resolved);
+            }
+        }
+
+        private Throwable resolveDelayedException() {
+            Iterator<Throwable> iterator = delayedExceptions.iterator();
+            Throwable result = iterator.next();
+            while (iterator.hasNext()) {
+                try {
+                    Throwable throwable = iterator.next();
+                    Throwable cause = throwable.getCause();
+                    if (cause == null) {
+                        try {
+                            throwable.initCause(result);
+                            result = throwable;
+                        } catch (IllegalStateException e) {
+                            result.addSuppressed(throwable);
+                            if (result.getSuppressed().length == 0) {
+                                result = new RuntimeException(result);
+                                result.addSuppressed(throwable);
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    result.addSuppressed(e);
+                }
+            }
+            return result;
+        }
+
+        @Override
+        public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+            if (hasSubscribed.compareAndSet(false, true)) {
+                targetSubscriber.set(subscriber);
+                sourcePublisher.get().subscribe(this);
+            } else {
+                subscriber.onSubscribe(new NoopSubscription(subscriber));
+                subscriber.onError(new IllegalStateException("only single subscriber allowed"));
+            }
+        }
+
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            if (isCancelled.get()) {
+                subscription.cancel();
+                return;
+            }
+            synchronized (this) {
+                sourceSubscription.set(subscription);
+                if (messagesRequested > 0) {
+                    subscription.request(messagesRequested);
+                }
+            }
+            if (hasOnSubscribedTarget.compareAndSet(false, true)) {
+                targetSubscriber.get().onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(ByteBuffer byteBuffer) {
+            long size = byteBuffer.remaining();
+            bytesReceived.add(size);
+            synchronized (this) {
+                messagesRequested--;
+            }
+            targetSubscriber.get().onNext(byteBuffer);
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            sourcePublisher.set(null);
+            sourceSubscription.set(null);
+            delayedExceptions.add(throwable);
+            if (!isCancelled.get() && retryLimit-- > 0) {
+                requestBuilder.range("bytes=" + bytesReceived + "-");
+                s3AsyncClient
+                    .getObject(requestBuilder.build(), this)
+                    .whenComplete((r, e) -> {
+                        if (e != null) {
+                            delayedExceptions.add(e);
+                            failTarget();
+                        }
+                    });
+            } else {
+                failTarget();
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            sourcePublisher.set(null);
+            sourceSubscription.set(null);
+            targetSubscriber.getAndSet(null).onComplete();
+        }
+
+        @Override
+        public void request(long amount) {
+            if (amount <= 0) {
+                throw new IllegalArgumentException("non-positive request amount");
+            }
+            synchronized (this) {
+                messagesRequested += amount;
+                Subscription s = sourceSubscription.get();
+                if (s != null) {
+                    s.request(amount);
+                }
+            }
+        }
+
+        @Override
+        public void cancel() {
+            isCancelled.set(true);
+            Subscription s = sourceSubscription.get();
+            if (s != null) {
+                s.cancel();
+            }
+        }
+    }
+}

--- a/src/test/java/io/burt/athena/AthenaStatementTest.java
+++ b/src/test/java/io/burt/athena/AthenaStatementTest.java
@@ -197,14 +197,14 @@ class AthenaStatementTest {
         class WhenInterruptedWhileSleeping {
             @BeforeEach
             void setUp() {
-                statement = new AthenaStatement(createConfiguration().withNetworkTimeout(Duration.ofMillis(10)), clock);
+                statement = new AthenaStatement(createConfiguration().withNetworkTimeout(Duration.ofSeconds(10)), clock);
             }
 
             @Test
             void throwsWhenStartQueryExecutionDurationExceedsNetworkTimeout() {
                 queryExecutionHelper.queueStartQueryResponse("Q1234");
                 queryExecutionHelper.queueGetQueryExecutionResponse(QueryExecutionState.SUCCEEDED);
-                queryExecutionHelper.delayStartQueryExecutionResponses(Duration.ofMillis(100));
+                queryExecutionHelper.delayStartQueryExecutionResponses(Duration.ofSeconds(100));
                 assertThrows(SQLTimeoutException.class, () -> statement.executeQuery("SELECT 1"));
             }
 
@@ -212,7 +212,7 @@ class AthenaStatementTest {
             void throwsWhenGetQueryExecutionDurationExceedsNetworkTimeout() {
                 queryExecutionHelper.queueStartQueryResponse("Q1234");
                 queryExecutionHelper.queueGetQueryExecutionResponse(QueryExecutionState.SUCCEEDED);
-                queryExecutionHelper.delayGetQueryExecutionResponses(Duration.ofMillis(100));
+                queryExecutionHelper.delayGetQueryExecutionResponses(Duration.ofSeconds(100));
                 assertThrows(SQLTimeoutException.class, () -> statement.executeQuery("SELECT 1"));
             }
         }
@@ -507,29 +507,29 @@ class AthenaStatementTest {
 
         @Test
         void setsTheTimeoutUsedForStartQueryExecution() throws SQLException {
-            queryExecutionHelper.delayStartQueryExecutionResponses(Duration.ofMillis(10));
+            queryExecutionHelper.delayStartQueryExecutionResponses(Duration.ofSeconds(10));
             statement.setQueryTimeout(0);
             assertThrows(SQLTimeoutException.class, () -> statement.executeQuery("SELECT 1"));
         }
 
         @Test
         void setsTheTimeoutUsedForGetQueryExecution() throws SQLException {
-            queryExecutionHelper.delayGetQueryExecutionResponses(Duration.ofMillis(10));
+            queryExecutionHelper.delayGetQueryExecutionResponses(Duration.ofSeconds(10));
             statement.setQueryTimeout(0);
             assertThrows(SQLTimeoutException.class, () -> statement.executeQuery("SELECT 1"));
         }
 
         @Test
         void setsTheTimeoutUsedForQuerySpanningMultipleOperations() {
-            queryExecutionHelper.delayStartQueryExecutionResponses(Duration.ofMillis(40));
-            queryExecutionHelper.delayGetQueryExecutionResponses(Duration.ofMillis(40));
-            statement.setQueryTimeout(Duration.ofMillis(100));
+            queryExecutionHelper.delayStartQueryExecutionResponses(Duration.ofSeconds(40));
+            queryExecutionHelper.delayGetQueryExecutionResponses(Duration.ofSeconds(40));
+            statement.setQueryTimeout(Duration.ofSeconds(100));
             assertThrows(SQLTimeoutException.class, () -> statement.executeQuery("SELECT 1"));
         }
 
         @Test
         void cancelsQueryAfterTimeout() throws Exception {
-            queryExecutionHelper.delayGetQueryExecutionResponses(Duration.ofMillis(10));
+            queryExecutionHelper.delayGetQueryExecutionResponses(Duration.ofSeconds(10));
             statement.setQueryTimeout(0);
             try { statement.executeQuery("SELECT 1"); } catch (SQLTimeoutException ste) { /* expected */ }
             StopQueryExecutionRequest request = queryExecutionHelper.stopQueryExecutionRequests().get(0);
@@ -538,7 +538,7 @@ class AthenaStatementTest {
 
         @Test
         void doesNotCancelQueryThatDidNotStart() throws Exception {
-            queryExecutionHelper.delayStartQueryExecutionResponses(Duration.ofMillis(10));
+            queryExecutionHelper.delayStartQueryExecutionResponses(Duration.ofSeconds(10));
             statement.setQueryTimeout(0);
             try { statement.executeQuery("SELECT 1"); } catch (SQLTimeoutException ste) { /* expected */ }
             assertEquals(0, queryExecutionHelper.stopQueryExecutionRequests().size());

--- a/src/test/java/io/burt/athena/result/S3ResultTest.java
+++ b/src/test/java/io/burt/athena/result/S3ResultTest.java
@@ -55,7 +55,7 @@ class S3ResultTest {
                 .resultConfiguration(b -> b.outputLocation("s3://some-bucket/the/prefix/Q1234.csv"))
                 .build();
         getObjectHelper = new GetObjectHelper();
-        result = new S3Result(getObjectHelper, queryExecution, Duration.ofSeconds(10));
+        result = new S3Result(getObjectHelper, 1, queryExecution, Duration.ofSeconds(10));
     }
 
     @AfterEach
@@ -123,7 +123,7 @@ class S3ResultTest {
                         .queryExecutionId("Q1234")
                         .resultConfiguration(b -> b.outputLocation("://some-bucket/the/prefix/Q1234.csv"))
                         .build();
-                Exception e = assertThrows(IllegalArgumentException.class, () -> new S3Result(getObjectHelper, queryExecution, Duration.ofSeconds(10)));
+                Exception e = assertThrows(IllegalArgumentException.class, () -> new S3Result(getObjectHelper, 0, queryExecution, Duration.ofSeconds(10)));
                 assertTrue(e.getMessage().contains("\"://some-bucket/the/prefix/Q1234.csv\""));
                 assertTrue(e.getMessage().contains("malformed"));
             }

--- a/src/test/java/io/burt/athena/result/S3ResultTest.java
+++ b/src/test/java/io/burt/athena/result/S3ResultTest.java
@@ -54,7 +54,7 @@ class S3ResultTest {
                 .resultConfiguration(b -> b.outputLocation("s3://some-bucket/the/prefix/Q1234.csv"))
                 .build();
         getObjectHelper = new GetObjectHelper();
-        result = new S3Result(getObjectHelper, queryExecution, Duration.ofMillis(10));
+        result = new S3Result(getObjectHelper, queryExecution, Duration.ofSeconds(10));
     }
 
     @AfterEach
@@ -122,7 +122,7 @@ class S3ResultTest {
                         .queryExecutionId("Q1234")
                         .resultConfiguration(b -> b.outputLocation("://some-bucket/the/prefix/Q1234.csv"))
                         .build();
-                Exception e = assertThrows(IllegalArgumentException.class, () -> new S3Result(getObjectHelper, queryExecution, Duration.ofMillis(10)));
+                Exception e = assertThrows(IllegalArgumentException.class, () -> new S3Result(getObjectHelper, queryExecution, Duration.ofSeconds(10)));
                 assertTrue(e.getMessage().contains("\"://some-bucket/the/prefix/Q1234.csv\""));
                 assertTrue(e.getMessage().contains("malformed"));
             }
@@ -213,7 +213,7 @@ class S3ResultTest {
         class WhenLoadingTheMetaDataTimesOut {
             @Test
             void throwsSqlTimeoutException() {
-                getObjectHelper.delayObject("some-bucket", "the/prefix/Q1234.csv.metadata", Duration.ofSeconds(1));
+                getObjectHelper.delayObject("some-bucket", "the/prefix/Q1234.csv.metadata", Duration.ofSeconds(60));
                 Exception e = assertThrows(SQLTimeoutException.class, () -> result.getMetaData());
                 assertEquals(TimeoutException.class, e.getCause().getClass());
             }
@@ -320,7 +320,7 @@ class S3ResultTest {
         class WhenLoadingTheResultTimesOut {
             @Test
             void throwsSqlTimeoutException() {
-                getObjectHelper.delayObject("some-bucket", "the/prefix/Q1234.csv", Duration.ofSeconds(1));
+                getObjectHelper.delayObject("some-bucket", "the/prefix/Q1234.csv", Duration.ofSeconds(60));
                 Exception e = assertThrows(SQLTimeoutException.class, () -> result.next());
                 assertEquals(TimeoutException.class, e.getCause().getClass());
             }

--- a/src/test/java/io/burt/athena/result/S3ResultTest.java
+++ b/src/test/java/io/burt/athena/result/S3ResultTest.java
@@ -325,6 +325,7 @@ class S3ResultTest {
             void setUp() {
                 getObjectHelper.removeObject("some-bucket", "the/prefix/Q1234.csv");
                 getObjectHelper.setObjectPublisher("some-bucket", "the/prefix/Q1234.csv", subscriber -> {
+                    getObjectHelper.removeObjectPublisher("some-bucket", "the/prefix/Q1234.csv");
                     this.subscriber = subscriber;
                     subscriber.onSubscribe(new Subscription() {
                         @Override

--- a/src/test/java/io/burt/athena/result/S3ResultTest.java
+++ b/src/test/java/io/burt/athena/result/S3ResultTest.java
@@ -349,6 +349,22 @@ class S3ResultTest {
                 assertEquals(RuntimeException.class, e.getCause().getCause().getClass());
                 assertEquals("b0rk", e.getCause().getCause().getMessage());
             }
+
+            @Nested
+            class AndTheErrorHappensBeforeTheIsConsumed {
+                @Test
+                void stillReturnsReceivedDataBeforeFailing() {
+                    assertDoesNotThrow(() -> result.next());
+                    subscriber.onNext(ByteBuffer.wrap("\",\"f\"\n\"g".getBytes(StandardCharsets.UTF_8)));
+                    subscriber.onError(new RuntimeException("b1rk"));
+                    assertDoesNotThrow(() -> result.next());
+                    assertEquals("e", result.getString(1));
+                    Exception e = assertThrows(SQLException.class, () -> result.next());
+                    assertEquals(IOException.class, e.getCause().getClass());
+                    assertEquals(RuntimeException.class, e.getCause().getCause().getClass());
+                    assertEquals("b1rk", e.getCause().getCause().getMessage());
+                }
+            }
         }
 
         @Nested

--- a/src/test/java/io/burt/athena/result/StandardResultTest.java
+++ b/src/test/java/io/burt/athena/result/StandardResultTest.java
@@ -45,7 +45,7 @@ class StandardResultTest {
 
     protected StandardResult createResult(AthenaAsyncClient athenaClient) {
         QueryExecution queryExecution = QueryExecution.builder().queryExecutionId("Q1234").build();
-        return new StandardResult(queryResultsHelper, queryExecution, 123, Duration.ofMillis(10));
+        return new StandardResult(queryResultsHelper, queryExecution, 123, Duration.ofSeconds(10));
     }
 
     @BeforeEach
@@ -348,7 +348,7 @@ class StandardResultTest {
             @Test
             void throwsSQLTimeoutException() {
                 QueryExecution queryExecution = QueryExecution.builder().queryExecutionId("Q1234").build();
-                queryResultsHelper.delayResponses(Duration.ofMillis(10));
+                queryResultsHelper.delayResponses(Duration.ofSeconds(10));
                 result = new StandardResult(queryResultsHelper, queryExecution, 123, Duration.ZERO);
                 Exception e = assertThrows(Exception.class, () -> result.next());
                 assertEquals(SQLTimeoutException.class, e.getClass());

--- a/src/test/java/io/burt/athena/result/s3/AsyncResumableGetObjectOperationTest.java
+++ b/src/test/java/io/burt/athena/result/s3/AsyncResumableGetObjectOperationTest.java
@@ -1,0 +1,345 @@
+package io.burt.athena.result.s3;
+
+import io.burt.athena.support.GetObjectHelper;
+import io.burt.athena.support.TestNameGenerator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(TestNameGenerator.class)
+public class AsyncResumableGetObjectOperationTest {
+    private GetObjectHelper getObjectHelper;
+    private Consumer<GetObjectRequest.Builder> requestBuilder;
+    private AsyncResponseTransformer<GetObjectResponse, Long> targetTransformer;
+    private CompletableFuture<Long> targetSubscriberCompletion;
+    private Subscriber<? super ByteBuffer> targetSubscriber;
+
+    private final List<ByteBuffer> resultBytes = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        getObjectHelper = new GetObjectHelper();
+        getObjectHelper.setObject("example-bucket", "path/to/my-key", new byte[44]);
+        requestBuilder = builder -> builder.bucket("example-bucket").key("path/to/my-key");
+        targetTransformer = spy(new AsyncResponseTransformer<GetObjectResponse, Long>() {
+            @Override
+            public CompletableFuture<Long> prepare() {
+                return CompletableFuture.completedFuture(1L);
+            }
+
+            @Override
+            public void onResponse(GetObjectResponse getObjectResponse) {
+            }
+
+            @Override
+            public void onStream(SdkPublisher<ByteBuffer> sdkPublisher) {
+                sdkPublisher.subscribe(targetSubscriber);
+            }
+
+            @Override
+            public void exceptionOccurred(Throwable throwable) {
+            }
+        });
+        targetSubscriberCompletion = new CompletableFuture<>();
+        targetSubscriber = spy(new Subscriber<ByteBuffer>() {
+            private Subscription subscription;
+            private long request = 1;
+
+            @Override
+            public void onSubscribe(Subscription subscription) {
+                this.subscription = subscription;
+                subscription.request(1);
+            }
+
+            @Override
+            public void onNext(ByteBuffer byteBuffer) {
+                resultBytes.add(byteBuffer);
+                subscription.request(request *= 2);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                targetSubscriberCompletion.completeExceptionally(throwable);
+            }
+
+            @Override
+            public void onComplete() {
+                targetSubscriberCompletion.complete(404L);
+            }
+        });
+    }
+
+    @AfterEach
+    void tearDown() {
+        getObjectHelper.close();
+    }
+
+    CompletableFuture<Long> call() {
+        return new AsyncResumableGetObjectOperation<>(getObjectHelper, requestBuilder, targetTransformer, 3).call();
+    }
+
+    private static class NoopSubscription implements Subscription {
+        @Override
+        public void request(long l) {
+        }
+
+        @Override
+        public void cancel() {
+        }
+    }
+
+    @Nested
+    class Call {
+        @Test
+        void performsAGetObjectRequest() throws ExecutionException, InterruptedException, TimeoutException {
+            assertEquals(1L, call().get(0, TimeUnit.DAYS));
+            assertEquals(Collections.singletonList(GetObjectRequest.builder().applyMutation(requestBuilder).build()), getObjectHelper.getObjectRequests());
+        }
+
+        @Nested
+        class WhenPrimaryRequestFails {
+
+            @BeforeEach
+            void setUp() {
+                getObjectHelper.setObjectException("example-bucket", "path/to/my-key", new UnsupportedOperationException("b0rk"));
+            }
+            @Test
+            void propagateTheFailure() {
+                Exception e = assertThrows(ExecutionException.class, () -> call().get(1, TimeUnit.DAYS));
+                assertEquals(UnsupportedOperationException.class, e.getCause().getClass());
+                assertEquals("b0rk", e.getCause().getMessage());
+            }
+        }
+
+        @Nested
+        class WhenPrimaryRequestSendFails {
+            @BeforeEach
+            void setUp() {
+                getObjectHelper.setObjectSendException("example-bucket", "path/to/my-key", new UnsupportedOperationException("b0rk"));
+            }
+
+            @Test
+            void propagateTheFailure() {
+                call();
+                ArgumentCaptor<Throwable> argumentCaptor = ArgumentCaptor.forClass(Throwable.class);
+                verify(targetTransformer).exceptionOccurred(argumentCaptor.capture());
+                Throwable throwable = argumentCaptor.getValue();
+                while (throwable instanceof CompletionException) {
+                    throwable = throwable.getCause();
+                }
+                assertEquals(UnsupportedOperationException.class, throwable.getClass());
+                assertEquals("b0rk", throwable.getMessage());
+            }
+        }
+
+        @Nested
+        class WhenDownloadingBodyFails {
+            private int attempt;
+
+            private final LinkedList<Subscription> subscriptions = new LinkedList<>();
+
+            @BeforeEach
+            void setUp() {
+                attempt = 1;
+                getObjectHelper.setObjectPublisher("example-bucket","path/to/my-key", SdkPublisher.adapt(s -> {
+                    subscriptions.add(spy(new Subscription() {
+                        private boolean first = true;
+                        @Override
+                        public void request(long l) {
+                            if (first) {
+                                first = false;
+                                ByteBuffer buffer = ByteBuffer.allocate(10);
+                                Arrays.fill(buffer.array(), (byte) ('@' + attempt++));
+                                s.onNext(buffer);
+                                s.onError(new TimeoutException("b0rk"));
+                            }
+                        }
+
+                        @Override
+                        public void cancel() {
+                        }
+                    }));
+                    s.onSubscribe(subscriptions.getLast());
+                }));
+            }
+
+            @Test
+            void performsThreeRetries() throws ExecutionException, InterruptedException, TimeoutException {
+                assertEquals(1L, call().get(0, TimeUnit.DAYS));
+                assertEquals(4, getObjectHelper.getObjectRequests().size());
+            }
+
+            @Test
+            void pushesDataFromSubsequentRequests() {
+                call();
+                assertEquals(
+                    Arrays.asList("AAAAAAAAAA", "BBBBBBBBBB", "CCCCCCCCCC", "DDDDDDDDDD"),
+                    resultBytes.stream().map(buffer -> StandardCharsets.ISO_8859_1.decode(buffer).toString()).collect(Collectors.toList())
+                );
+            }
+
+            @Test
+            void includesTheOriginalEtagAsIfMatchInSubsequentRequests() {
+                call();
+                assertNull(getObjectHelper.getObjectRequests().get(0).ifMatch());
+                assertEquals("tag-1", getObjectHelper.getObjectRequests().get(1).ifMatch());
+            }
+
+            @Test
+            void requestOnlyRemainingByteRange() {
+                call();
+                assertNull(getObjectHelper.getObjectRequests().get(0).range());
+                assertEquals("bytes=10-", getObjectHelper.getObjectRequests().get(1).range());
+                assertEquals("bytes=20-", getObjectHelper.getObjectRequests().get(2).range());
+                assertEquals("bytes=30-", getObjectHelper.getObjectRequests().get(3).range());
+            }
+
+            @Test
+            void propagatesRequestsForAdditionalData() {
+                call();
+                verify(subscriptions.get(0)).request(1L);
+                verify(subscriptions.get(0)).request(2L);
+                verify(subscriptions.get(1)).request(4L);
+                verify(subscriptions.get(2)).request(8L);
+                verify(subscriptions.get(3)).request(16L);
+            }
+
+            @Test
+            void reissuesOutstandingRequestsOnRetries() {
+                call();
+                verify(subscriptions.get(1)).request(1L+2L-1L);
+                verify(subscriptions.get(2)).request(1L+2L+4L-1L-1L);
+                verify(subscriptions.get(3)).request(1L+2L+4L+8L-1L-1L-1L);
+            }
+
+            @Nested
+            class AndExplicitlyCancelled {
+                @BeforeEach
+                void setUp() {
+                    targetSubscriber = new Subscriber<ByteBuffer>() {
+                        @Override
+                        public void onSubscribe(Subscription subscription) {
+                            subscription.cancel();
+                        }
+
+                        @Override
+                        public void onNext(ByteBuffer byteBuffer) {
+
+                        }
+
+                        @Override
+                        public void onError(Throwable throwable) {
+
+                        }
+
+                        @Override
+                        public void onComplete() {
+
+                        }
+                    };
+                }
+
+                @Test
+                void cancelSourceSubscription() {
+                    call();
+                    verify(subscriptions.get(0)).cancel();
+                }
+
+                @Test
+                void preventRetries() {
+                    call();
+                    assertEquals(1, getObjectHelper.getObjectRequests().size());
+                }
+            }
+
+            @Nested
+            class AndSubsequentRequestFutureFails {
+                @BeforeEach
+                void setUp() {
+                    getObjectHelper.setObjectPublisher("example-bucket","path/to/my-key", SdkPublisher.adapt(s -> {
+                        getObjectHelper.removeObject("example-bucket", "path/to/my-key");
+                        getObjectHelper.removeObjectPublisher("example-bucket", "path/to/my-key");
+                        s.onSubscribe(new NoopSubscription());
+                        s.onError(new RuntimeException("b0rk"));
+                    }));
+                }
+
+                @Test
+                void behavesLikeALateErrorInTheOriginalRequest() {
+                    call();
+                    ArgumentCaptor<Throwable> argumentCaptor = ArgumentCaptor.forClass(Throwable.class);
+                    verify(targetSubscriber).onError(argumentCaptor.capture());
+                    Throwable throwable = argumentCaptor.getValue();
+                    assertEquals(RuntimeException.class, throwable.getClass());
+                    assertEquals("b0rk", throwable.getMessage());
+                    assertEquals(NoSuchKeyException.class, throwable.getSuppressed()[0].getClass());
+                }
+            }
+
+            @Nested
+            class AndSubsequentRequestFailsEarly {
+                @BeforeEach
+                void setUp() {
+                    getObjectHelper.setObjectPublisher("example-bucket","path/to/my-key", SdkPublisher.adapt(s -> {
+                        getObjectHelper.setObjectSendException("example-bucket", "path/to/my-key", new RuntimeException("second"));
+                        s.onSubscribe(new NoopSubscription());
+                        s.onError(new RuntimeException("b0rk"));
+                    }));
+                }
+
+                @Test
+                void behavesLikeALateErrorInTheOriginalRequest() {
+                    call();
+                    ArgumentCaptor<Throwable> argumentCaptor = ArgumentCaptor.forClass(Throwable.class);
+                    verify(targetSubscriber).onError(argumentCaptor.capture());
+                    Throwable throwable = argumentCaptor.getValue();
+                    assertEquals(RuntimeException.class, throwable.getClass());
+                    assertEquals("second", throwable.getMessage());
+                }
+
+                @Test
+                void callsOnErrorExactlyOnce() {
+                    call();
+                    verify(targetSubscriber, times(1)).onError(any());
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/io/burt/athena/support/QueryExecutionHelper.java
+++ b/src/test/java/io/burt/athena/support/QueryExecutionHelper.java
@@ -139,7 +139,7 @@ public class QueryExecutionHelper implements AthenaAsyncClient {
         if (delay.isZero()) {
             return future;
         } else {
-            return TestDelayedCompletableFuture.create(future, delay, clock);
+            return TestDelayedCompletableFuture.wrapWithDelay(future, delay, clock);
         }
     }
 

--- a/src/test/java/io/burt/athena/support/QueryExecutionHelper.java
+++ b/src/test/java/io/burt/athena/support/QueryExecutionHelper.java
@@ -1,6 +1,5 @@
 package io.burt.athena.support;
 
-import org.mockito.AdditionalAnswers;
 import software.amazon.awssdk.services.athena.AthenaAsyncClient;
 import software.amazon.awssdk.services.athena.model.ColumnInfo;
 import software.amazon.awssdk.services.athena.model.GetQueryExecutionRequest;
@@ -19,16 +18,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
 
 public class QueryExecutionHelper implements AthenaAsyncClient {
     private final List<StartQueryExecutionRequest> startQueryRequests;
@@ -147,16 +139,7 @@ public class QueryExecutionHelper implements AthenaAsyncClient {
         if (delay.isZero()) {
             return future;
         } else {
-            TestDelayedCompletableFuture<T> testFuture = new TestDelayedCompletableFuture<>(future, delay, clock);
-            @SuppressWarnings("unchecked") CompletableFuture<T> restrictedFuture = mock(CompletableFuture.class, invocation -> {
-                throw new UnsupportedOperationException(invocation.getMethod().toString());
-            });
-            try {
-                doAnswer(AdditionalAnswers.delegatesTo(testFuture)).when(restrictedFuture).get(anyLong(), any());
-            } catch (ExecutionException | InterruptedException | TimeoutException e) {
-                throw new RuntimeException(e);
-            }
-            return restrictedFuture;
+            return TestDelayedCompletableFuture.create(future, delay, clock);
         }
     }
 

--- a/src/test/java/io/burt/athena/support/TestClock.java
+++ b/src/test/java/io/burt/athena/support/TestClock.java
@@ -4,9 +4,10 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class TestClock extends Clock {
-  private long millis;
+  private AtomicLong millis = new AtomicLong();
 
   @Override
   public ZoneId getZone() {
@@ -25,10 +26,10 @@ public class TestClock extends Clock {
 
   @Override
   public long millis() {
-    return this.millis;
+    return this.millis.get();
   }
 
   public void tick(Duration duration) {
-    this.millis += duration.toMillis();
+    this.millis.addAndGet(duration.toMillis());
   }
 }

--- a/src/test/java/io/burt/athena/support/TestDelayedCompletableFuture.java
+++ b/src/test/java/io/burt/athena/support/TestDelayedCompletableFuture.java
@@ -19,6 +19,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
 
 public class TestDelayedCompletableFuture<T> extends CompletableFuture<T> {
     private static final Executor EXECUTOR = Executors.newCachedThreadPool();
@@ -26,12 +27,16 @@ public class TestDelayedCompletableFuture<T> extends CompletableFuture<T> {
     private CompletableFuture<T> wrappedFuture;
     private TestClock clock;
 
-
     public static <T> CompletableFuture<T> wrap(CompletableFuture<T> future, TestClock clock) {
         TestDelayedCompletableFuture<T> testFuture = new TestDelayedCompletableFuture<>(future, clock);
-        @SuppressWarnings("unchecked") TestDelayedCompletableFuture<T> restrictedFuture = mock(TestDelayedCompletableFuture.class, invocation -> {
-            throw new UnsupportedOperationException(invocation.getMethod().toString());
-        });
+        @SuppressWarnings("unchecked") TestDelayedCompletableFuture<T> restrictedFuture = mock(
+            TestDelayedCompletableFuture.class,
+            withSettings()
+              .stubOnly()
+              .defaultAnswer(invocation -> {
+                throw new UnsupportedOperationException(invocation.getMethod().toString());
+            })
+        );
         try {
             Stubber stubber = lenient().doAnswer(AdditionalAnswers.delegatesTo(testFuture));
             stubber.when(restrictedFuture).getWrappedFuture();

--- a/src/test/java/io/burt/athena/support/TestDelayedCompletableFuture.java
+++ b/src/test/java/io/burt/athena/support/TestDelayedCompletableFuture.java
@@ -12,6 +12,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -44,6 +45,7 @@ public class TestDelayedCompletableFuture<T> extends CompletableFuture<T> {
             stubber.when(restrictedFuture).thenApply(any());
             stubber.when(restrictedFuture).thenCombine(any(), any());
             stubber.when(restrictedFuture).toString();
+            stubber.when(restrictedFuture).whenComplete(any());
         } catch (ExecutionException | InterruptedException | TimeoutException e) {
             throw new RuntimeException(e);
         }
@@ -104,5 +106,10 @@ public class TestDelayedCompletableFuture<T> extends CompletableFuture<T> {
     @SuppressWarnings("unchecked")
     public <U, V> CompletableFuture<V> thenCombine(CompletionStage<? extends U> other, BiFunction<? super T, ? super U, ? extends V> fn) {
         return new TestDelayedCompletableFuture<>(unwrap(wrappedFuture.thenCombine(unwrap(other), fn)), clock);
+    }
+
+    @Override
+    public CompletableFuture<T> whenComplete(BiConsumer<? super T, ? super Throwable> action) {
+        return new TestDelayedCompletableFuture<>(unwrap(wrappedFuture.whenComplete(action)), clock);
     }
 }

--- a/src/test/java/io/burt/athena/support/TestDelayedCompletableFuture.java
+++ b/src/test/java/io/burt/athena/support/TestDelayedCompletableFuture.java
@@ -1,0 +1,32 @@
+package io.burt.athena.support;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class TestDelayedCompletableFuture<T> extends CompletableFuture<T> {
+    public CompletableFuture<T> wrappedFuture;
+    public Instant finishedAt;
+    public TestClock clock;
+
+    public TestDelayedCompletableFuture(CompletableFuture<T> wrappedFuture, Duration delay, TestClock clock) {
+        this.wrappedFuture = wrappedFuture;
+        this.finishedAt = clock.instant().plus(delay);
+        this.clock = clock;
+    }
+
+    @Override
+    public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        Instant deadline = clock.instant().plusMillis(unit.toMillis(timeout));
+        if (deadline.isBefore(finishedAt)) {
+            clock.tick(Duration.ofMillis(deadline.toEpochMilli()));
+            throw new TimeoutException("simulated timeout");
+        } else {
+            clock.tick(Duration.ofMillis(finishedAt.toEpochMilli()));
+            return wrappedFuture.get();
+        }
+    }
+}

--- a/src/test/java/io/burt/athena/support/TestDelayedCompletableFuture.java
+++ b/src/test/java/io/burt/athena/support/TestDelayedCompletableFuture.java
@@ -1,52 +1,103 @@
 package io.burt.athena.support;
 
 import org.mockito.AdditionalAnswers;
+import org.mockito.stubbing.Stubber;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
 public class TestDelayedCompletableFuture<T> extends CompletableFuture<T> {
-    public CompletableFuture<T> wrappedFuture;
-    public Instant finishedAt;
-    public TestClock clock;
+    private static final Executor EXECUTOR = Executors.newCachedThreadPool();
 
-    static <T> CompletableFuture<T> create(CompletableFuture<T> future, Duration delay, TestClock clock) {
-        TestDelayedCompletableFuture<T> testFuture = new TestDelayedCompletableFuture<>(future, delay, clock);
-        @SuppressWarnings("unchecked") CompletableFuture<T> restrictedFuture = mock(CompletableFuture.class, invocation -> {
+    private CompletableFuture<T> wrappedFuture;
+    private TestClock clock;
+
+
+    public static <T> CompletableFuture<T> wrap(CompletableFuture<T> future, TestClock clock) {
+        TestDelayedCompletableFuture<T> testFuture = new TestDelayedCompletableFuture<>(future, clock);
+        @SuppressWarnings("unchecked") TestDelayedCompletableFuture<T> restrictedFuture = mock(TestDelayedCompletableFuture.class, invocation -> {
             throw new UnsupportedOperationException(invocation.getMethod().toString());
         });
         try {
-            doAnswer(AdditionalAnswers.delegatesTo(testFuture)).when(restrictedFuture).get(anyLong(), any());
+            Stubber stubber = lenient().doAnswer(AdditionalAnswers.delegatesTo(testFuture));
+            stubber.when(restrictedFuture).getWrappedFuture();
+            stubber.when(restrictedFuture).get(anyLong(), any());
+            stubber.when(restrictedFuture).thenApply(any());
+            stubber.when(restrictedFuture).thenCombine(any(), any());
+            stubber.when(restrictedFuture).toString();
         } catch (ExecutionException | InterruptedException | TimeoutException e) {
             throw new RuntimeException(e);
         }
         return restrictedFuture;
     }
 
-    private TestDelayedCompletableFuture(CompletableFuture<T> wrappedFuture, Duration delay, TestClock clock) {
+    public static <T> CompletableFuture<T> wrapWithDelay(CompletableFuture<T> future, Duration delay, TestClock clock) {
+        if (delay == null || delay.compareTo(Duration.ZERO) <= 0) {
+            return wrap(future, clock);
+        } else {
+            CompletableFuture<T> newFuture = new CompletableFuture<>();
+            EXECUTOR.execute(() -> {
+                clock.tick(delay);
+                try {
+                    newFuture.complete(future.get());
+                } catch (Exception e) {
+                    newFuture.completeExceptionally(e);
+                }
+            });
+            return wrap(newFuture, clock);
+        }
+    }
+
+    private TestDelayedCompletableFuture(CompletableFuture<T> wrappedFuture, TestClock clock) {
         this.wrappedFuture = wrappedFuture;
-        this.finishedAt = clock.instant().plus(delay);
         this.clock = clock;
+    }
+
+    public CompletableFuture<T> getWrappedFuture() {
+        return wrappedFuture;
+    }
+
+    private <U> CompletableFuture<U> unwrap(CompletionStage<U> stage) {
+        if (stage instanceof TestDelayedCompletableFuture) {
+            return ((TestDelayedCompletableFuture<U>) stage).getWrappedFuture();
+        } else {
+            return stage.toCompletableFuture();
+        }
     }
 
     @Override
     public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-        Instant deadline = clock.instant().plusMillis(unit.toMillis(timeout));
-        if (deadline.isBefore(finishedAt)) {
-            clock.tick(Duration.ofMillis(deadline.toEpochMilli()));
+        Instant deadline = Instant.ofEpochMilli(unit.toMillis(timeout));
+        T result = wrappedFuture.get(timeout, unit);
+        if (deadline.isBefore(clock.instant())) {
             throw new TimeoutException("simulated timeout");
         } else {
-            clock.tick(Duration.ofMillis(finishedAt.toEpochMilli()));
-            return wrappedFuture.get();
+            return result;
         }
+    }
+
+    @Override
+    public <U> CompletableFuture<U> thenApply(Function<? super T, ? extends U> fn) {
+        return new TestDelayedCompletableFuture<>(unwrap(wrappedFuture.thenApply(fn)), clock);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <U, V> CompletableFuture<V> thenCombine(CompletionStage<? extends U> other, BiFunction<? super T, ? super U, ? extends V> fn) {
+        return new TestDelayedCompletableFuture<>(unwrap(wrappedFuture.thenCombine(unwrap(other), fn)), clock);
     }
 }

--- a/src/test/java/io/burt/athena/support/TestDelayedCompletableFuture.java
+++ b/src/test/java/io/burt/athena/support/TestDelayedCompletableFuture.java
@@ -1,5 +1,7 @@
 package io.burt.athena.support;
 
+import org.mockito.AdditionalAnswers;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
@@ -7,12 +9,30 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
 public class TestDelayedCompletableFuture<T> extends CompletableFuture<T> {
     public CompletableFuture<T> wrappedFuture;
     public Instant finishedAt;
     public TestClock clock;
 
-    public TestDelayedCompletableFuture(CompletableFuture<T> wrappedFuture, Duration delay, TestClock clock) {
+    static <T> CompletableFuture<T> create(CompletableFuture<T> future, Duration delay, TestClock clock) {
+        TestDelayedCompletableFuture<T> testFuture = new TestDelayedCompletableFuture<>(future, delay, clock);
+        @SuppressWarnings("unchecked") CompletableFuture<T> restrictedFuture = mock(CompletableFuture.class, invocation -> {
+            throw new UnsupportedOperationException(invocation.getMethod().toString());
+        });
+        try {
+            doAnswer(AdditionalAnswers.delegatesTo(testFuture)).when(restrictedFuture).get(anyLong(), any());
+        } catch (ExecutionException | InterruptedException | TimeoutException e) {
+            throw new RuntimeException(e);
+        }
+        return restrictedFuture;
+    }
+
+    private TestDelayedCompletableFuture(CompletableFuture<T> wrappedFuture, Duration delay, TestClock clock) {
         this.wrappedFuture = wrappedFuture;
         this.finishedAt = clock.instant().plus(delay);
         this.clock = clock;


### PR DESCRIPTION
Before this change, the results from S3 are streamed using a single request, which works well when the results are immediately consumed (and works reasonable well when the results are processed in a constant relatively slow rate). But if you process the result set in pages, with large delays between each chunk, it breaks down, as the S3 connection is terminated.

While it would be possible to fix this by keeping the connection to S3 open for longer time periods, that is generally not a good idea, and would in any case be hampered by any transient connectivity issues.

This changes the downloading of the Athena result CSV to handle errors while streaming the results so that another S3 request is restarted at the offset where the previous one failed. This means that a pause between pages will essentially be handled as if we kept the connection open, but with the added benefit that we don't keep the resources allocated, and that we could handle transient network errors in a similar fashion.

This also implement a couple of related changes. First, instead of making the input stream immediately fail on an asynchronous error, we now allow processing of the potentially megabytes of buffered data before doing so. It might be that input stream consumer doesn't care about the complete response, but only the first portion, and then it seems wasteful to discard the buffered data.

This also fixes the S3Result#next error handling to expose errors as `SQLException` instead of `RuntimeException`.

Finally, this makes some improvements to the test helpers that was needed to get this working.

The change is based on top of #20 