### PR TITLE
Add retries for the S3 object input stream

### DIFF
--- a/src/main/java/io/burt/athena/result/S3Result.java
+++ b/src/main/java/io/burt/athena/result/S3Result.java
@@ -114,7 +114,17 @@ public class S3Result implements Result {
                 throw new SQLException(e);
             }
         }
-        currentRow = responseParser.next();
+        try {
+            currentRow = responseParser.next();
+        } catch (RuntimeException e) {
+            if (!(e.getCause() instanceof RuntimeException)) {
+                SQLException ee = new SQLException(e.getCause());
+                ee.addSuppressed(e);
+                throw ee;
+            } else {
+                throw e;
+            }
+        }
         if (currentRow == null) {
             return false;
         } else {

--- a/src/main/java/io/burt/athena/result/S3Result.java
+++ b/src/main/java/io/burt/athena/result/S3Result.java
@@ -3,9 +3,10 @@ package io.burt.athena.result;
 import io.burt.athena.AthenaResultSetMetaData;
 import io.burt.athena.result.csv.VeryBasicCsvParser;
 import io.burt.athena.result.s3.ByteBufferResponseTransformer;
-import io.burt.athena.result.s3.InputStreamResponseTransformer;
+import io.burt.athena.result.s3.GetObjectInputStreamTransformer;
 import software.amazon.awssdk.services.athena.model.QueryExecution;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 
 import java.io.BufferedReader;
@@ -64,7 +65,8 @@ public class S3Result implements Result {
         try {
             AthenaMetaDataParser metaDataParser = new AthenaMetaDataParser(queryExecution);
             CompletableFuture<AthenaResultSetMetaData> metadataFuture = s3Client.getObject(b -> b.bucket(bucketName).key(key + ".metadata"), new ByteBufferResponseTransformer()).thenApply(metaDataParser::parse);
-            CompletableFuture<InputStream> responseStreamFuture = s3Client.getObject(b -> b.bucket(bucketName).key(key), new InputStreamResponseTransformer());
+            GetObjectRequest.Builder requestBuilder = GetObjectRequest.builder().bucket(bucketName).key(key);
+            CompletableFuture<InputStream> responseStreamFuture = s3Client.getObject(requestBuilder.build(), new GetObjectInputStreamTransformer(s3Client,requestBuilder, timeout));
             CompletableFuture<ResponseParser> combinedFuture = metadataFuture.thenCombine(responseStreamFuture, (metaData, responseStream) -> new ResponseParser(responseStream, metaData));
             responseParser = combinedFuture.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
             responseParser.next();

--- a/src/main/java/io/burt/athena/result/s3/GetObjectInputStreamTransformer.java
+++ b/src/main/java/io/burt/athena/result/s3/GetObjectInputStreamTransformer.java
@@ -1,0 +1,75 @@
+package io.burt.athena.result.s3;
+
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class GetObjectInputStreamTransformer extends InputStreamResponseTransformer {
+    private final S3AsyncClient s3Client;
+    private final GetObjectRequest.Builder requestBuilder;
+    private Duration timeout;
+    private int bytesOffset = 0;
+
+    public GetObjectInputStreamTransformer(S3AsyncClient s3Client, GetObjectRequest.Builder requestBuilder, Duration timeout) {
+        this.s3Client = s3Client;
+        this.requestBuilder = requestBuilder;
+        this.timeout = timeout;
+    }
+
+    @Override
+    public void onResponse(GetObjectResponse r) {
+        requestBuilder.ifMatch(r.eTag());
+        super.onResponse(r);
+    }
+
+    @Override
+    protected boolean ensureChunk() throws IOException {
+        try {
+            return super.ensureChunk();
+        } catch (IOException cause) {
+            Throwable originalError = error;
+            try {
+                error = null;
+                readChunk = null;
+                chunks.clear();
+                requestBuilder.range("bytes=" + bytesOffset + "-");
+                s3Client.getObject(requestBuilder.build(), this)
+                    .get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+                return super.ensureChunk();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                cause.addSuppressed(e);
+                error = originalError;
+                throw cause;
+            } catch (ExecutionException | IOException | TimeoutException e) {
+                cause.addSuppressed(e);
+                error = originalError;
+                throw cause;
+            }
+        }
+    }
+
+    @Override
+    public int read(byte[] destination, int offset, int length) throws IOException {
+        int bytesRead = super.read(destination, offset, length);
+        if (bytesRead >= 0) {
+            bytesOffset += bytesRead;
+        }
+        return bytesRead;
+    }
+
+    @Override
+    public int read() throws IOException {
+        int byteValue = super.read();
+        if (byteValue >= 0) {
+            bytesOffset++;
+        }
+        return byteValue;
+    }
+}

--- a/src/main/java/io/burt/athena/result/s3/GetObjectInputStreamTransformer.java
+++ b/src/main/java/io/burt/athena/result/s3/GetObjectInputStreamTransformer.java
@@ -13,13 +13,12 @@ import java.util.concurrent.TimeoutException;
 public class GetObjectInputStreamTransformer extends InputStreamResponseTransformer {
     private final S3AsyncClient s3Client;
     private final GetObjectRequest.Builder requestBuilder;
-    private Duration timeout;
     private int bytesOffset = 0;
 
     public GetObjectInputStreamTransformer(S3AsyncClient s3Client, GetObjectRequest.Builder requestBuilder, Duration timeout) {
+        super(timeout);
         this.s3Client = s3Client;
         this.requestBuilder = requestBuilder;
-        this.timeout = timeout;
     }
 
     @Override

--- a/src/main/java/io/burt/athena/result/s3/InputStreamResponseTransformer.java
+++ b/src/main/java/io/burt/athena/result/s3/InputStreamResponseTransformer.java
@@ -24,12 +24,12 @@ public class InputStreamResponseTransformer extends InputStream implements Async
     private static final float CHUNK_SIZE_INITIAL_ESTIMATE = 8192f;
 
     private final CompletableFuture<InputStream> future;
-    private final BlockingQueue<ByteBuffer> chunks;
+    protected final BlockingQueue<ByteBuffer> chunks;
 
     private GetObjectResponse response;
     private AtomicReference<Optional<Subscription>> subscription;
-    private ByteBuffer readChunk;
-    private Throwable error;
+    protected ByteBuffer readChunk;
+    protected Throwable error;
     private AtomicInteger approximateBufferSize;
     private AtomicInteger requests;
     private volatile float approximateChunkSize;
@@ -125,7 +125,7 @@ public class InputStreamResponseTransformer extends InputStream implements Async
         }
     }
 
-    private boolean ensureChunk() throws IOException {
+    protected boolean ensureChunk() throws IOException {
         if (readChunk == END_MARKER) {
             if (error != null) {
                 throw new IOException(error);

--- a/src/test/java/io/burt/athena/result/S3ResultTest.java
+++ b/src/test/java/io/burt/athena/result/S3ResultTest.java
@@ -325,6 +325,7 @@ class S3ResultTest {
             void setUp() {
                 getObjectHelper.removeObject("some-bucket", "the/prefix/Q1234.csv");
                 getObjectHelper.setObjectPublisher("some-bucket", "the/prefix/Q1234.csv", subscriber -> {
+                    getObjectHelper.removeObjectPublisher("some-bucket", "the/prefix/Q1234.csv");
                     this.subscriber = subscriber;
                     subscriber.onSubscribe(new Subscription() {
                         @Override

--- a/src/test/java/io/burt/athena/result/S3ResultTest.java
+++ b/src/test/java/io/burt/athena/result/S3ResultTest.java
@@ -352,7 +352,7 @@ class S3ResultTest {
             }
 
             @Nested
-            class AndTheErrorHappensBeforeTheIsConsumed {
+            class AndTheErrorHappensBeforeTheResultIsConsumed {
                 @Test
                 void stillReturnsReceivedDataBeforeFailing() {
                     assertDoesNotThrow(() -> result.next());
@@ -449,7 +449,7 @@ class S3ResultTest {
         }
 
         @Nested
-        class WhenInvalidCsvReturned {
+        class WhenInvalidCsvIsReturned {
             @BeforeEach
             void setUp() {
                 getObjectHelper.setObject("some-bucket", "the/prefix/Q1234.csv", "\"col1\",\"col2\"\n\"a".getBytes(StandardCharsets.UTF_8));

--- a/src/test/java/io/burt/athena/result/S3ResultTest.java
+++ b/src/test/java/io/burt/athena/result/S3ResultTest.java
@@ -349,6 +349,22 @@ class S3ResultTest {
                 assertEquals(RuntimeException.class, e.getCause().getCause().getClass());
                 assertEquals("b0rk", e.getCause().getCause().getMessage());
             }
+
+            @Nested
+            class AndTheErrorHappensBeforeTheIsConsumed {
+                @Test
+                void stillReturnsReceivedDataBeforeFailing() {
+                    assertDoesNotThrow(() -> result.next());
+                    subscriber.onNext(ByteBuffer.wrap("\",\"f\"\n\"g".getBytes(StandardCharsets.UTF_8)));
+                    subscriber.onError(new RuntimeException("b1rk"));
+                    assertDoesNotThrow(() -> result.next());
+                    assertEquals("e", result.getString(1));
+                    Exception e = assertThrows(SQLException.class, () -> result.next());
+                    assertEquals(IOException.class, e.getCause().getClass());
+                    assertEquals(RuntimeException.class, e.getCause().getCause().getClass());
+                    assertEquals("b1rk", e.getCause().getCause().getMessage());
+                }
+            }
         }
 
         @Nested

--- a/src/test/java/io/burt/athena/result/s3/GetObjectInputStreamTransformerTest.java
+++ b/src/test/java/io/burt/athena/result/s3/GetObjectInputStreamTransformerTest.java
@@ -1,0 +1,153 @@
+package io.burt.athena.result.s3;
+
+import io.burt.athena.support.GetObjectHelper;
+import io.burt.athena.support.TestNameGenerator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.utils.IoUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(TestNameGenerator.class)
+public class GetObjectInputStreamTransformerTest {
+    private GetObjectHelper getObjectHelper;
+    private GetObjectRequest.Builder requestBuilder;
+    private GetObjectInputStreamTransformer subject;
+
+    @BeforeEach
+    void setUp() {
+        getObjectHelper = new GetObjectHelper();
+        getObjectHelper.setObject("example-bucket", "path/to/my-key", "abcd".getBytes(StandardCharsets.UTF_8));
+        requestBuilder = GetObjectRequest.builder().bucket("example-bucket").key("path/to/my-key");
+        subject = new GetObjectInputStreamTransformer(getObjectHelper, requestBuilder, Duration.ofSeconds(1));
+    }
+
+    @AfterEach
+    void tearDown() {
+        getObjectHelper.close();
+    }
+
+    CompletableFuture<InputStream> call() {
+        return getObjectHelper.getObject(requestBuilder.build(), subject);
+    }
+
+    private static class NoopSubscription implements Subscription {
+        @Override
+        public void request(long l) {
+        }
+
+        @Override
+        public void cancel() {
+        }
+    }
+
+    @Nested
+    class Read {
+        @Test
+        void returnsStreamedContent() throws ExecutionException, InterruptedException, TimeoutException, IOException {
+            assertEquals("abcd", IoUtils.toUtf8String(call().get(0, TimeUnit.DAYS)));
+            assertEquals(Collections.singletonList(GetObjectRequest.builder().bucket("example-bucket").key("path/to/my-key").build()), getObjectHelper.getObjectRequests());
+        }
+
+        @Nested
+        class WhenRequestFails {
+            @BeforeEach
+            void setUp() {
+                getObjectHelper.setObjectException("example-bucket", "path/to/my-key", new UnsupportedOperationException("b0rk"));
+            }
+            @Test
+            void propagateTheFailure() {
+                Exception e = assertThrows(ExecutionException.class, () -> call().get(1, TimeUnit.DAYS));
+                assertEquals(UnsupportedOperationException.class, e.getCause().getClass());
+                assertEquals("b0rk", e.getCause().getMessage());
+            }
+        }
+
+        @Nested
+        class WhenDownloadingBodyFails {
+            @BeforeEach
+            void setUp() {
+                getObjectHelper.setObjectPublisher("example-bucket","path/to/my-key", SdkPublisher.adapt(s -> {
+                    getObjectHelper.removeObjectPublisher("example-bucket", "path/to/my-key");
+                    s.onSubscribe(new NoopSubscription());
+                    s.onNext(ByteBuffer.wrap("1234".getBytes(StandardCharsets.UTF_8)));
+                    s.onError(new TimeoutException("b0rk"));
+                }));
+            }
+
+            @Test
+            void retriesOnce() {
+                call();
+                IoUtils.drainInputStream(subject);
+                assertEquals(2, getObjectHelper.getObjectRequests().size());
+            }
+
+            @Test
+            void pushesDataFromRetry() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+                assertEquals("1234abcd", IoUtils.toUtf8String(call().get(0, TimeUnit.DAYS)));
+            }
+
+            @Test
+            void includesTheOriginalEtagAsIfMatchInSubsequentRequests() {
+                call();
+                IoUtils.drainInputStream(subject);
+                assertNull(getObjectHelper.getObjectRequests().get(0).ifMatch());
+                assertEquals("tag-1", getObjectHelper.getObjectRequests().get(1).ifMatch());
+            }
+
+            @Test
+            void requestOnlyRemainingByteRange() {
+                call();
+                IoUtils.drainInputStream(subject);
+                assertNull(getObjectHelper.getObjectRequests().get(0).range());
+                assertEquals("bytes=4-", getObjectHelper.getObjectRequests().get(1).range());
+            }
+
+            @Nested
+            class AndRetryFails {
+                @BeforeEach
+                void setUp() {
+                    getObjectHelper.setObjectPublisher("example-bucket","path/to/my-key", SdkPublisher.adapt(s -> {
+                        getObjectHelper.removeObject("example-bucket", "path/to/my-key");
+                        getObjectHelper.removeObjectPublisher("example-bucket", "path/to/my-key");
+                        s.onSubscribe(new NoopSubscription());
+                        s.onError(new RuntimeException("b0rk"));
+                    }));
+                }
+
+                @Test
+                void propagatesOriginalFailureWithSubsequentFailureSupressed() {
+                    Throwable throwable = assertThrows(IOException.class, () -> IoUtils.toUtf8String(call().get(1, TimeUnit.SECONDS)));
+                    assertEquals(RuntimeException.class, throwable.getCause().getClass());
+                    assertEquals("b0rk", throwable.getCause().getMessage());
+                    assertEquals(ExecutionException.class, throwable.getSuppressed()[0].getClass());
+                    assertEquals(NoSuchKeyException.class, throwable.getSuppressed()[0].getCause().getClass());
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/io/burt/athena/result/s3/GetObjectInputStreamTransformerTest.java
+++ b/src/test/java/io/burt/athena/result/s3/GetObjectInputStreamTransformerTest.java
@@ -74,13 +74,13 @@ public class GetObjectInputStreamTransformerTest {
         }
 
         @Nested
-        class WhenRequestFails {
+        class WhenTheRequestFails {
             @BeforeEach
             void setUp() {
                 getObjectHelper.setObjectException("example-bucket", "path/to/my-key", new UnsupportedOperationException("b0rk"));
             }
             @Test
-            void propagateTheFailure() {
+            void propagatesTheFailure() {
                 Exception e = assertThrows(ExecutionException.class, () -> call().get(1, TimeUnit.DAYS));
                 assertEquals(UnsupportedOperationException.class, e.getCause().getClass());
                 assertEquals("b0rk", e.getCause().getMessage());
@@ -88,7 +88,7 @@ public class GetObjectInputStreamTransformerTest {
         }
 
         @Nested
-        class WhenDownloadingBodyFails {
+        class WhenDownloadingTheBodyFails {
             @BeforeEach
             void setUp() {
                 getObjectHelper.setObjectPublisher("example-bucket","path/to/my-key", SdkPublisher.adapt(s -> {

--- a/src/test/java/io/burt/athena/support/GetObjectHelper.java
+++ b/src/test/java/io/burt/athena/support/GetObjectHelper.java
@@ -68,6 +68,10 @@ public class GetObjectHelper implements S3AsyncClient, AutoCloseable {
         objects.remove(uri(bucket, key));
     }
 
+    public void removeObjectPublisher(String bucket, String key) {
+        publishers.remove(uri(bucket, key));
+    }
+
     public void delayObject(String bucket, String key, Duration duration) {
         delays.put(uri(bucket, key), duration);
     }
@@ -169,7 +173,7 @@ public class GetObjectHelper implements S3AsyncClient, AutoCloseable {
             future = new CompletableFuture<>();
             future.completeExceptionally(exceptions.get(uri));
         } else if (lateExceptions.containsKey(uri)) {
-            GetObjectResponse response = GetObjectResponse.builder().contentLength(0L).build();
+            GetObjectResponse response = GetObjectResponse.builder().contentLength(0L).eTag("tag-1").build();
             future = requestTransformer.prepare();
             requestTransformer.onResponse(response);
             requestTransformer.exceptionOccurred(lateExceptions.get(uri));
@@ -177,13 +181,13 @@ public class GetObjectHelper implements S3AsyncClient, AutoCloseable {
             requestTransformer.onStream(publisher);
             closeables.add(publisher);
         } else if (publishers.containsKey(uri)) {
-            GetObjectResponse response = GetObjectResponse.builder().contentLength(0L).build();
+            GetObjectResponse response = GetObjectResponse.builder().contentLength(0L).eTag("tag-1").build();
             future = requestTransformer.prepare();
             requestTransformer.onResponse(response);
             requestTransformer.onStream(publishers.get(uri));
         } else if (objects.containsKey(uri)) {
             byte[] object = objects.get(uri);
-            GetObjectResponse response = GetObjectResponse.builder().contentLength((long) object.length).build();
+            GetObjectResponse response = GetObjectResponse.builder().contentLength((long) object.length).eTag("tag-1").build();
             future = requestTransformer.prepare();
             requestTransformer.onResponse(response);
             GetObjectPublisher publisher = new GetObjectPublisher(object);


### PR DESCRIPTION
Similarly to #21, this changes the downloading of the Athena result CSV to handle errors when reading the results so that another S3 request is restarted at the offset where the previous one failed.

Compared to the approach in #21, this represents a much simpler solution. While #21 attempted to inject similar behavior between the S3 client and the `AsyncResponseTransformer`, this instead implements the retries on top of the input stream. There are two main reasons why that results in a simpler implementation. First, the `InputStream` interface is much simpler than the `AsyncResponseTransformer` one, and secondly, in our setting, the `InputStream` is guaranteed to only be read from one thread, whereas that is not generally true for an `AsyncResponseTransformer`.

This produces slightly different results, as an attempt to reconnect wouldn't happen until we have consumed all of the buffered data, whereas the previous approach would try to fill up the buffer even in the presence of errors. In theory, the original approach could provide lower latency, in particular for the case of transient network failures. However, for the pagination case, which was the main motivation for introducing the feature, the simpler approach seems more reasonable, as every read would run the risk of timing out in that setting.

This PR still brings along most of the small improvements from #21, and in addition adds timeouts to the `InputStreamResponseTransformer#read` method, which before this could in theory block indefinitely.