### PR TITLE
Ensure Mockito is not included at compile time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
       <version>${mockito.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Mockito is only used in the tests of this library and should not normally be compiled into the final Jar

Thanks!